### PR TITLE
Add argocd utils + readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+freeze:
+	scripts/freeze.sh
+
+format:
+	scripts/format.sh

--- a/kubernetes/argocd/Readme.md
+++ b/kubernetes/argocd/Readme.md
@@ -1,0 +1,16 @@
+# ArgoCD bindings for dhall
+
+This package contains bindings for using dhall with [ArgoCD](https://argoproj.github.io/argo-cd/) 1.2 . You can see the types represented in the root directory, each one with a `Type.dhall` and `default.dhall` (except for unions, where you will find a `TypesUnion.dhall`).
+
+## Installation
+To properly use dhall with argocd, you need to install dhall-to-yaml in argocd-repo-server.
+See [ArgoCD's docs](https://argoproj.github.io/argo-cd/operator-manual/custom_tools/#adding-tools-via-volume-mounts) for more information.
+
+## Usage
+See [examples].
+
+### Higher level (helper) functions
+See [examples/app.dhall] for how to define an application using higher level functions
+
+### Raw bindings
+See [examples/project.dhall] for how to define a project using the raw bindings.

--- a/kubernetes/argocd/example/app.dhall
+++ b/kubernetes/argocd/example/app.dhall
@@ -1,0 +1,28 @@
+let argocd =
+        ../package.dhall sha256:a4daab169373a4e6a52d10345ccdb579ef5115fad4544db386e0ee8dad14928b
+      ? ../package.dhall
+
+let config =
+      argocd.util.AppConfig.DhallAppConfig
+        (     argocd.util.DhallAppConfig.default
+          //  { name =
+                  "my-app"
+              , project =
+                    ./projectName.dhall sha256:d7e4e24f5750f02229d03a034faabf0f3378960c20170d83e78ab83c1131aded
+                  ? ./projectName.dhall
+              , source =
+                      argocd.util.Source.default
+                  //  { url =
+                          "https://github.com/my_org/my_repo.git"
+                      , path =
+                          "k8s"
+                      }
+              , destination =
+                    ./destination.dhall sha256:c42b35050c674d39753b5f45d211bf5aef40f0bcd0d73f8d1d7f0046fb668a2d
+                  ? ./destination.dhall
+              , parameters =
+                  [ { name = "IMAGE_VERSION", value = "latest" } ]
+              }
+        )
+
+in  argocd.util.makeApp config

--- a/kubernetes/argocd/example/destination.dhall
+++ b/kubernetes/argocd/example/destination.dhall
@@ -1,0 +1,1 @@
+{ server = "https://kubernetes.default.svc", namespace = "default" }

--- a/kubernetes/argocd/example/project.dhall
+++ b/kubernetes/argocd/example/project.dhall
@@ -1,0 +1,31 @@
+let argocd =
+        ../package.dhall sha256:a4daab169373a4e6a52d10345ccdb579ef5115fad4544db386e0ee8dad14928b
+      ? ../package.dhall
+
+let k8s =
+        ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+      ? ../../k8s/package.dhall
+
+in  argocd.TypesUnion.Project
+      (     argocd.Project.default
+        //  { metadata =
+                    k8s.defaults.ObjectMeta
+                //  { name =
+                          ./projectName.dhall sha256:d7e4e24f5750f02229d03a034faabf0f3378960c20170d83e78ab83c1131aded
+                        ? ./projectName.dhall
+                    }
+            , spec =
+                    argocd.ProjectSpec.default
+                //  { description =
+                        "ArgoCD Example Project"
+                    , sourceRepos =
+                        [   ./repo.dhall sha256:d6ee23f065555c0ad8a59cfeaf0d06f5b2f030a1bf91960c50a66e31937bcb74
+                          ? ./repo.dhall
+                        ]
+                    , destinations =
+                        [   ./destination.dhall sha256:c42b35050c674d39753b5f45d211bf5aef40f0bcd0d73f8d1d7f0046fb668a2d
+                          ? ./destination.dhall
+                        ]
+                    }
+            }
+      )

--- a/kubernetes/argocd/example/projectName.dhall
+++ b/kubernetes/argocd/example/projectName.dhall
@@ -1,0 +1,1 @@
+"my-project"

--- a/kubernetes/argocd/example/repo.dhall
+++ b/kubernetes/argocd/example/repo.dhall
@@ -1,0 +1,1 @@
+"https://github.com/your-org/your-repo.git"

--- a/kubernetes/argocd/package.dhall
+++ b/kubernetes/argocd/package.dhall
@@ -49,4 +49,7 @@
 , TypesUnion =
       ./TypesUnion.dhall sha256:78e4af72e3e73d3eb67ecf4e431cf93ee3213d15ed42326f163aafed0a0ba866
     ? ./TypesUnion.dhall
+, util =
+      ./util/package.dhall sha256:5f953306c20ac996192e19dec24c040ef1414cd0cd29cb31d6d075fd4c81ffa8
+    ? ./util/package.dhall
 }

--- a/kubernetes/argocd/util/AppConfig.dhall
+++ b/kubernetes/argocd/util/AppConfig.dhall
@@ -1,0 +1,7 @@
+< HelmAppConfig :
+      ./HelmAppConfig/Type.dhall sha256:b868c82151c0eb1467b51a7f42be8ccd0c0abb58fd74536672b2de843a21b35a
+    ? ./HelmAppConfig/Type.dhall
+| DhallAppConfig :
+      ./DhallAppConfig/Type.dhall sha256:29d9330057fd7c24f43be6d3f0df79ec67b8c1966482b1dbc11b5d74ab1bb0c4
+    ? ./DhallAppConfig/Type.dhall
+>

--- a/kubernetes/argocd/util/DhallAppConfig/Type.dhall
+++ b/kubernetes/argocd/util/DhallAppConfig/Type.dhall
@@ -1,0 +1,26 @@
+{ name :
+    Text
+, project :
+    Text
+, destination :
+      ../../DestinationSpec/Type.dhall sha256:689554a30489cd60c83a1581ebf4b8de25acd1f6fc9fe7fbfff940b87ae018a3
+    ? ../../DestinationSpec/Type.dhall
+, source :
+      ../Source/Type.dhall sha256:67125442fdf84e7c9f4a613237be378974cfe6a26a7fec08fedc5045fceed45d
+    ? ../Source/Type.dhall
+, parameters :
+    List
+      (   ../../Parameter/Type.dhall sha256:b8c3c0c4ceb36ba4e6674df5de20ad1d97e120b93b9ce9914a41d0036770dcc4
+        ? ../../Parameter/Type.dhall
+      )
+, ignoreDifferences :
+    List
+      (   ../../Difference/Type.dhall sha256:34e396f57549c6855081ee922624f429efd83112e32b707017efdffe0ef6db7f
+        ? ../../Difference/Type.dhall
+      )
+, syncPolicy :
+    Optional
+      (   ../../SyncPolicy/Type.dhall sha256:c08cba845720619a88473776d513ea1f9fcb360f93b509caa59ef724df77f1ef
+        ? ../../SyncPolicy/Type.dhall
+      )
+}

--- a/kubernetes/argocd/util/DhallAppConfig/default.dhall
+++ b/kubernetes/argocd/util/DhallAppConfig/default.dhall
@@ -1,0 +1,16 @@
+{ parameters =
+    [] : List
+           (   ../../Parameter/Type.dhall sha256:b8c3c0c4ceb36ba4e6674df5de20ad1d97e120b93b9ce9914a41d0036770dcc4
+             ? ../../Parameter/Type.dhall
+           )
+, ignoreDifferences =
+    [] : List
+           (   ../../Difference/Type.dhall sha256:34e396f57549c6855081ee922624f429efd83112e32b707017efdffe0ef6db7f
+             ? ../../Difference/Type.dhall
+           )
+, syncPolicy =
+    None
+      (   ../../SyncPolicy/Type.dhall sha256:c08cba845720619a88473776d513ea1f9fcb360f93b509caa59ef724df77f1ef
+        ? ../../SyncPolicy/Type.dhall
+      )
+}

--- a/kubernetes/argocd/util/DhallAppConfig/package.dhall
+++ b/kubernetes/argocd/util/DhallAppConfig/package.dhall
@@ -1,0 +1,7 @@
+{ default =
+      ./default.dhall sha256:55396077b22eda7c582bfe491f6b4998b3e0e54f800038e7443fce110082e431
+    ? ./default.dhall
+, Type =
+      ./Type.dhall sha256:29d9330057fd7c24f43be6d3f0df79ec67b8c1966482b1dbc11b5d74ab1bb0c4
+    ? ./Type.dhall
+}

--- a/kubernetes/argocd/util/HelmAppConfig/Type.dhall
+++ b/kubernetes/argocd/util/HelmAppConfig/Type.dhall
@@ -1,0 +1,28 @@
+{ name :
+    Text
+, project :
+    Text
+, destination :
+      ../../DestinationSpec/Type.dhall sha256:689554a30489cd60c83a1581ebf4b8de25acd1f6fc9fe7fbfff940b87ae018a3
+    ? ../../DestinationSpec/Type.dhall
+, source :
+      ../Source/Type.dhall sha256:67125442fdf84e7c9f4a613237be378974cfe6a26a7fec08fedc5045fceed45d
+    ? ../Source/Type.dhall
+, parameters :
+    List
+      (   ../../Parameter/Type.dhall sha256:b8c3c0c4ceb36ba4e6674df5de20ad1d97e120b93b9ce9914a41d0036770dcc4
+        ? ../../Parameter/Type.dhall
+      )
+, valueFiles :
+    List Text
+, ignoreDifferences :
+    List
+      (   ../../Difference/Type.dhall sha256:34e396f57549c6855081ee922624f429efd83112e32b707017efdffe0ef6db7f
+        ? ../../Difference/Type.dhall
+      )
+, syncPolicy :
+    Optional
+      (   ../../SyncPolicy/Type.dhall sha256:c08cba845720619a88473776d513ea1f9fcb360f93b509caa59ef724df77f1ef
+        ? ../../SyncPolicy/Type.dhall
+      )
+}

--- a/kubernetes/argocd/util/HelmAppConfig/default.dhall
+++ b/kubernetes/argocd/util/HelmAppConfig/default.dhall
@@ -1,0 +1,18 @@
+{ parameters =
+    [] : List
+           (   ../../Parameter/Type.dhall sha256:b8c3c0c4ceb36ba4e6674df5de20ad1d97e120b93b9ce9914a41d0036770dcc4
+             ? ../../Parameter/Type.dhall
+           )
+, valueFiles =
+    [] : List Text
+, ignoreDifferences =
+    [] : List
+           (   ../../Difference/Type.dhall sha256:34e396f57549c6855081ee922624f429efd83112e32b707017efdffe0ef6db7f
+             ? ../../Difference/Type.dhall
+           )
+, syncPolicy =
+    None
+      (   ../../SyncPolicy/Type.dhall sha256:c08cba845720619a88473776d513ea1f9fcb360f93b509caa59ef724df77f1ef
+        ? ../../SyncPolicy/Type.dhall
+      )
+}

--- a/kubernetes/argocd/util/HelmAppConfig/package.dhall
+++ b/kubernetes/argocd/util/HelmAppConfig/package.dhall
@@ -1,0 +1,7 @@
+{ default =
+      ./default.dhall sha256:f4edf99d5771a3977571e3c85345e92532abc5d2826e4b263ad5f8fbf092f2db
+    ? ./default.dhall
+, Type =
+      ./Type.dhall sha256:b868c82151c0eb1467b51a7f42be8ccd0c0abb58fd74536672b2de843a21b35a
+    ? ./Type.dhall
+}

--- a/kubernetes/argocd/util/Source/Type.dhall
+++ b/kubernetes/argocd/util/Source/Type.dhall
@@ -1,0 +1,1 @@
+{ url : Text, path : Text, targetRevision : Optional Text }

--- a/kubernetes/argocd/util/Source/default.dhall
+++ b/kubernetes/argocd/util/Source/default.dhall
@@ -1,0 +1,1 @@
+{ targetRevision = None Text }

--- a/kubernetes/argocd/util/Source/package.dhall
+++ b/kubernetes/argocd/util/Source/package.dhall
@@ -1,0 +1,7 @@
+{ Type =
+      ./Type.dhall sha256:67125442fdf84e7c9f4a613237be378974cfe6a26a7fec08fedc5045fceed45d
+    ? ./Type.dhall
+, default =
+      ./default.dhall sha256:8acdc984bfd6b5ab47caf4d0c3f66b95621e5ffb3bc1fe5cd6e3f81a82421c5d
+    ? ./default.dhall
+}

--- a/kubernetes/argocd/util/internal/makeDhallApp.dhall
+++ b/kubernetes/argocd/util/internal/makeDhallApp.dhall
@@ -1,0 +1,74 @@
+{-
+    This assumes that you have installed dhall-to-yaml
+    in your argocd repo server.
+    See https://argoproj.github.io/argo-cd/operator-manual/custom_tools/#adding-tools-via-volume-mounts
+    for more information
+-}
+let TypesUnion =
+        ../../TypesUnion.dhall sha256:78e4af72e3e73d3eb67ecf4e431cf93ee3213d15ed42326f163aafed0a0ba866
+      ? ../../TypesUnion.dhall
+
+let Application =
+        ../../Application/package.dhall sha256:8ccca3adfe68d6acb15cf540b6d2595967cd508fc59ea3ccaa586e35b503f973
+      ? ../../Application/package.dhall
+
+let ApplicationSpec =
+        ../../ApplicationSpec/package.dhall sha256:f8a31d4039c8c96352f45414fd2cdfe9ab981a7c036904bd4d4c13ed7762dd44
+      ? ../../ApplicationSpec/package.dhall
+
+let SourceSpec =
+        ../../SourceSpec/package.dhall sha256:edb5091c3a6d426780564c737853f3a4478466f2a92cc50e4e44a85d28eb8481
+      ? ../../SourceSpec/package.dhall
+
+let PluginSourceSpec =
+        ../../PluginSourceSpec/package.dhall sha256:0d6745d353c85c4724b82b3bdba302e8c524349ee2b3a5d68c6916072af39b97
+      ? ../../PluginSourceSpec/package.dhall
+
+let PluginSpec =
+        ../../PluginSpec/package.dhall sha256:fd9dd420c9ea830231af7e7893ea217f2f7ca35c313cd0a319f80443ac6c84b9
+      ? ../../PluginSpec/package.dhall
+
+let k8s =
+        ../../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+      ? ../../../k8s/package.dhall
+
+in      \ ( appConfig
+          :   ../DhallAppConfig/Type.dhall sha256:29d9330057fd7c24f43be6d3f0df79ec67b8c1966482b1dbc11b5d74ab1bb0c4
+            ? ../DhallAppConfig/Type.dhall
+          )
+    ->    TypesUnion.Application
+            (     Application.default
+              //  { metadata =
+                      k8s.defaults.ObjectMeta // { name = appConfig.name }
+                  , spec =
+                          ApplicationSpec.default
+                      //  { project =
+                              appConfig.project
+                          , source =
+                              SourceSpec.TypesUnion.Plugin
+                                (     PluginSourceSpec.default
+                                  //  { repoURL =
+                                          appConfig.source.url
+                                      , path =
+                                          appConfig.source.path
+                                      , targetRevision =
+                                          appConfig.source.targetRevision
+                                      , plugin =
+                                              PluginSpec.default
+                                          //  { name =
+                                                  "dhall-to-yaml"
+                                              , env =
+                                                  Some appConfig.parameters
+                                              }
+                                      }
+                                )
+                          , destination =
+                              appConfig.destination
+                          , syncPolicy =
+                              appConfig.syncPolicy
+                          , ignoreDifferences =
+                              Some appConfig.ignoreDifferences
+                          }
+                  }
+            )
+        : TypesUnion

--- a/kubernetes/argocd/util/internal/makeHelmApp.dhall
+++ b/kubernetes/argocd/util/internal/makeHelmApp.dhall
@@ -1,0 +1,68 @@
+let TypesUnion =
+        ../../TypesUnion.dhall sha256:78e4af72e3e73d3eb67ecf4e431cf93ee3213d15ed42326f163aafed0a0ba866
+      ? ../../TypesUnion.dhall
+
+let Application =
+        ../../Application/package.dhall sha256:8ccca3adfe68d6acb15cf540b6d2595967cd508fc59ea3ccaa586e35b503f973
+      ? ../../Application/package.dhall
+
+let ApplicationSpec =
+        ../../ApplicationSpec/package.dhall sha256:f8a31d4039c8c96352f45414fd2cdfe9ab981a7c036904bd4d4c13ed7762dd44
+      ? ../../ApplicationSpec/package.dhall
+
+let SourceSpec =
+        ../../SourceSpec/package.dhall sha256:edb5091c3a6d426780564c737853f3a4478466f2a92cc50e4e44a85d28eb8481
+      ? ../../SourceSpec/package.dhall
+
+let HelmSourceSpec =
+        ../../HelmSourceSpec/package.dhall sha256:380ded7e9ccb3e786facd647fd0d28bb6df20b9dce93e194413b7f6968a39a53
+      ? ../../HelmSourceSpec/package.dhall
+
+let HelmSpec =
+        ../../HelmSpec/package.dhall sha256:1614bee24c1c396e322f826350481349c3c1342e1e6edcdae7c6925bc9c2224a
+      ? ../../HelmSpec/package.dhall
+
+let k8s =
+        ../../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+      ? ../../../k8s/package.dhall
+
+in      \ ( appConfig
+          :   ../HelmAppConfig/Type.dhall sha256:b868c82151c0eb1467b51a7f42be8ccd0c0abb58fd74536672b2de843a21b35a
+            ? ../HelmAppConfig/Type.dhall
+          )
+    ->    TypesUnion.Application
+            (     Application.default
+              //  { metadata =
+                      k8s.defaults.ObjectMeta // { name = appConfig.name }
+                  , spec =
+                          ApplicationSpec.default
+                      //  { project =
+                              appConfig.project
+                          , source =
+                              SourceSpec.TypesUnion.Helm
+                                (     HelmSourceSpec.default
+                                  //  { repoURL =
+                                          appConfig.source.url
+                                      , path =
+                                          appConfig.source.path
+                                      , targetRevision =
+                                          appConfig.source.targetRevision
+                                      , helm =
+                                              HelmSpec.default
+                                          //  { valueFiles =
+                                                  Some appConfig.valueFiles
+                                              , parameters =
+                                                  Some appConfig.parameters
+                                              }
+                                      }
+                                )
+                          , destination =
+                              appConfig.destination
+                          , syncPolicy =
+                              appConfig.syncPolicy
+                          , ignoreDifferences =
+                              Some appConfig.ignoreDifferences
+                          }
+                  }
+            )
+        : TypesUnion

--- a/kubernetes/argocd/util/makeApp.dhall
+++ b/kubernetes/argocd/util/makeApp.dhall
@@ -1,0 +1,13 @@
+    \ ( appConfig
+      :   ./AppConfig.dhall sha256:1775eb24a12afb4e8ef0495040c5ba95e46672ff5eb99d187785c4124f273ec8
+        ? ./AppConfig.dhall
+      )
+->  merge
+      { DhallAppConfig =
+            ./internal/makeDhallApp.dhall sha256:e8cd843fce0a7cb29232d32b948347fe2aff37bb05f1a7fd87bddcda3949dfd8
+          ? ./internal/makeDhallApp.dhall
+      , HelmAppConfig =
+            ./internal/makeHelmApp.dhall sha256:774c1f9cdef222c4fda50c920a6f2833bc27cfc77cd545f9a20a78f770a0cecf
+          ? ./internal/makeHelmApp.dhall
+      }
+      appConfig

--- a/kubernetes/argocd/util/package.dhall
+++ b/kubernetes/argocd/util/package.dhall
@@ -1,0 +1,19 @@
+{ makeApp =
+      ./makeApp.dhall sha256:ffc8f218fa372bc43104c8d9b6851a220b4f230eec65b00de327d003f2ee983c
+    ? ./makeApp.dhall
+, withSyncWave =
+      ./withSyncWave.dhall sha256:1ac32a0da61336c5c6d43609b24ba2804c01d4c5b084565c74568964c1f98119
+    ? ./withSyncWave.dhall
+, AppConfig =
+      ./AppConfig.dhall sha256:1775eb24a12afb4e8ef0495040c5ba95e46672ff5eb99d187785c4124f273ec8
+    ? ./AppConfig.dhall
+, DhallAppConfig =
+      ./DhallAppConfig/package.dhall sha256:b3c7ac222cfee6002a3f530ee606a132e2961a289f8ad6c46a2156369ad27c06
+    ? ./DhallAppConfig/package.dhall
+, HelmAppConfig =
+      ./HelmAppConfig/package.dhall sha256:79427a8574bcf671e658f4efedfd57028a973c387feebee20faa334b0dbd4826
+    ? ./HelmAppConfig/package.dhall
+, Source =
+      ./Source/package.dhall sha256:6e4dcf3915d1baf344bfbd884c563c58009eb66ee31cf0f4ff36cb9d4f0828e2
+    ? ./Source/package.dhall
+}

--- a/kubernetes/argocd/util/withSyncWave.dhall
+++ b/kubernetes/argocd/util/withSyncWave.dhall
@@ -5,9 +5,17 @@ let k8s =
         ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
       ? ../../k8s/package.dhall
 
-let argocd =
-        ../package.dhall sha256:a4daab169373a4e6a52d10345ccdb579ef5115fad4544db386e0ee8dad14928b
-      ? ../package.dhall
+let Project =
+        ../Project/package.dhall sha256:43e36b1dc0eec92d602643cbee9b21bf5d27b8912cabf8d88a1776b5a5b1f7d8
+      ? ../Project/package.dhall
+
+let Application =
+        ../Application/package.dhall sha256:8ccca3adfe68d6acb15cf540b6d2595967cd508fc59ea3ccaa586e35b503f973
+      ? ../Application/package.dhall
+
+let TypesUnion =
+        ../TypesUnion.dhall sha256:78e4af72e3e73d3eb67ecf4e431cf93ee3213d15ed42326f163aafed0a0ba866
+      ? ../TypesUnion.dhall
 
 let withSyncWaveMetadata =
           \(wave : Integer)
@@ -22,18 +30,18 @@ let withSyncWaveMetadata =
 
 let withSyncWaveApplication =
           \(wave : Integer)
-      ->  \(app : argocd.Application.Type)
-      ->  argocd.TypesUnion.Application
+      ->  \(app : Application.Type)
+      ->  TypesUnion.Application
             (app // { metadata = withSyncWaveMetadata wave app.metadata })
 
 let withSyncWaveProject =
           \(wave : Integer)
-      ->  \(proj : argocd.Project.Type)
-      ->  argocd.TypesUnion.Project
+      ->  \(proj : Project.Type)
+      ->  TypesUnion.Project
             (proj // { metadata = withSyncWaveMetadata wave proj.metadata })
 
 in      \(wave : Integer)
-    ->  \(argocdUnion : argocd.TypesUnion)
+    ->  \(argocdUnion : TypesUnion)
     ->  merge
           { Application =
               withSyncWaveApplication wave

--- a/kubernetes/argocd/util/withSyncWave.dhall
+++ b/kubernetes/argocd/util/withSyncWave.dhall
@@ -1,0 +1,43 @@
+{-
+    Utility to add sync waves to argocd applications and projects.
+-}
+let k8s =
+        ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+      ? ../../k8s/package.dhall
+
+let argocd =
+        ../package.dhall sha256:a4daab169373a4e6a52d10345ccdb579ef5115fad4544db386e0ee8dad14928b
+      ? ../package.dhall
+
+let withSyncWaveMetadata =
+          \(wave : Integer)
+      ->  \(metadata : k8s.types.ObjectMeta)
+      ->      metadata
+          //  { annotations =
+                    metadata.annotations
+                  # ( toMap
+                        { `argocd.argoproj.io/sync-wave` = Integer/show wave }
+                    )
+              }
+
+let withSyncWaveApplication =
+          \(wave : Integer)
+      ->  \(app : argocd.Application.Type)
+      ->  argocd.TypesUnion.Application
+            (app // { metadata = withSyncWaveMetadata wave app.metadata })
+
+let withSyncWaveProject =
+          \(wave : Integer)
+      ->  \(proj : argocd.Project.Type)
+      ->  argocd.TypesUnion.Project
+            (proj // { metadata = withSyncWaveMetadata wave proj.metadata })
+
+in      \(wave : Integer)
+    ->  \(argocdUnion : argocd.TypesUnion)
+    ->  merge
+          { Application =
+              withSyncWaveApplication wave
+          , Project =
+              withSyncWaveProject wave
+          }
+          argocdUnion

--- a/kubernetes/package.dhall
+++ b/kubernetes/package.dhall
@@ -8,6 +8,6 @@
       ./k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
     ? ./k8s/package.dhall
 , argocd =
-      ./argocd/package.dhall sha256:2ffb8f8c08d9fab22ecca3e1c15489c684f50fe65441e6c2254d262338acfaf9
+      ./argocd/package.dhall sha256:a4daab169373a4e6a52d10345ccdb579ef5115fad4544db386e0ee8dad14928b
     ? ./argocd/package.dhall
 }

--- a/package.dhall
+++ b/package.dhall
@@ -1,5 +1,5 @@
 { kubernetes =
-      ./kubernetes/package.dhall sha256:565402478f425ea952752a3e88a13522cfa4177976237190f7312bf65551a6c2
+      ./kubernetes/package.dhall sha256:6f4eb0b20a4364b6d90d925f04fc83677d26510b57a42f17b030745489885319
     ? ./kubernetes/package.dhall
 , Prelude =
       https://prelude.dhall-lang.org/v10.0.0/package.dhall sha256:771c7131fc87e13eb18f770a27c59f9418879f7e230ba2a50e46f4461f43ec69

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,5 +1,5 @@
 for file in $(find . -name '*.dhall'); do
     echo "${file}"
 
-    dhall --ascii freeze --all --cache --inplace "${file}"
+    dhall --ascii format --inplace "${file}"
 done


### PR DESCRIPTION
This adds some higher level utility functions built on top the bindings to make creating apps simple. It also includes an /example directory and a small readme.