### PR TITLE
Fix argocd ApplicationSpec default and update examples with new :: syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,30 +34,26 @@ let argocd = packages.kubernetes.argocd
 
 let k8s = packages.kubernetes.k8s
 
-in      argocd.Application.default
-    //  { metadata =
-            k8s.defaults.ObjectMeta // { name = "hello-app" }
-        , spec =
-                argocd.ApplicationSpec.default
-            //  { project =
-                    "hello-project"
-                , source =
-                        argocd.SourceSpec.TypesUnion.Plugin (argocd.PluginSourceSpec.default
-                    //  { repoURL = "https://github.com/EarnestResearch/dhall-packages.git",
-                          path = "kubernetes",
-                            plugin =
-                            argocd.PluginSpec.default // { name =
-                                "dhall-to-yaml"
-                            }
-                        })
-                , destination =
-                    argocd.DestinationSpec.default // {
-                        server = "kubernetes.svc.local",
-                        namespace = "default"
-                    }
-                }
-        } : argocd.Application.Type
-
+in  argocd.Application::{
+    , metadata = k8s.defaults.ObjectMeta // { name = "hello-app" }
+    , spec =
+        argocd.ApplicationSpec::{
+        , project = "hello-project"
+        , source =
+            argocd.SourceSpec.TypesUnion.Plugin
+              argocd.PluginSourceSpec::{
+              , repoURL =
+                  "https://github.com/EarnestResearch/dhall-packages.git"
+              , path = "kubernetes"
+              , plugin = argocd.PluginSpec::{ name = "dhall-to-yaml" }
+              }
+        , destination =
+            argocd.DestinationSpec::{
+            , server = "kubernetes.svc.local"
+            , namespace = "default"
+            }
+        }
+    }
 ```
 
 If you don't want to download the entire packages collection, you can simply reference the `package.dhall` file in the directory you are interested in. This will greatly improve performance if you are only using a subset of the packages.

--- a/kubernetes/argocd/ApplicationSpec/default.dhall
+++ b/kubernetes/argocd/ApplicationSpec/default.dhall
@@ -3,4 +3,11 @@
       (   ../SyncPolicy/Type.dhall sha256:c08cba845720619a88473776d513ea1f9fcb360f93b509caa59ef724df77f1ef
         ? ../SyncPolicy/Type.dhall
       )
+, ignoreDifferences =
+    None
+      ( List
+          (   ../Difference/Type.dhall sha256:34e396f57549c6855081ee922624f429efd83112e32b707017efdffe0ef6db7f
+            ? ../Difference/Type.dhall
+          )
+      )
 }

--- a/kubernetes/argocd/ApplicationSpec/package.dhall
+++ b/kubernetes/argocd/ApplicationSpec/package.dhall
@@ -2,6 +2,6 @@
       ./Type.dhall sha256:c2239be50d38d6e45cbbfcedd4817cbbb5c9a937cd20ab554508009452e4b001
     ? ./Type.dhall
 , default =
-      ./default.dhall sha256:66b9d68d400de71d2e499b89b80f029d7c55ad661da543ccc51c9a7b33ec6742
+      ./default.dhall sha256:6665e953ac5ebc5dd95a4b0528fc48fab7da85067688db3f8ae3ef1c87419eab
     ? ./default.dhall
 }

--- a/kubernetes/argocd/example/app.dhall
+++ b/kubernetes/argocd/example/app.dhall
@@ -4,22 +4,20 @@ let argocd =
 
 let config =
       argocd.util.AppConfig.DhallAppConfig
-        (     argocd.util.DhallAppConfig.default
-          //  { name =
-                  "my-app"
-              , project =
-                    ./projectName.dhall sha256:d7e4e24f5750f02229d03a034faabf0f3378960c20170d83e78ab83c1131aded
-                  ? ./projectName.dhall
-              , source =
-                      argocd.util.Source.default
-                  //  { url = "https://github.com/my_org/my_repo.git"
-                      , path = "k8s"
-                      }
-              , destination =
-                    ./destination.dhall sha256:c42b35050c674d39753b5f45d211bf5aef40f0bcd0d73f8d1d7f0046fb668a2d
-                  ? ./destination.dhall
-              , parameters = [ { name = "IMAGE_VERSION", value = "latest" } ]
-              }
-        )
+        argocd.util.DhallAppConfig::{
+        , name = "my-app"
+        , project =
+              ./projectName.dhall sha256:d7e4e24f5750f02229d03a034faabf0f3378960c20170d83e78ab83c1131aded
+            ? ./projectName.dhall
+        , source =
+            argocd.util.Source::{
+            , url = "https://github.com/my_org/my_repo.git"
+            , path = "k8s"
+            }
+        , destination =
+              ./destination.dhall sha256:c42b35050c674d39753b5f45d211bf5aef40f0bcd0d73f8d1d7f0046fb668a2d
+            ? ./destination.dhall
+        , parameters = [ { name = "IMAGE_VERSION", value = "latest" } ]
+        }
 
 in  argocd.util.makeApp config

--- a/kubernetes/argocd/example/project.dhall
+++ b/kubernetes/argocd/example/project.dhall
@@ -7,25 +7,23 @@ let k8s =
       ? ../../k8s/package.dhall
 
 in  argocd.TypesUnion.Project
-      (     argocd.Project.default
-        //  { metadata =
-                    k8s.defaults.ObjectMeta
-                //  { name =
-                          ./projectName.dhall sha256:d7e4e24f5750f02229d03a034faabf0f3378960c20170d83e78ab83c1131aded
-                        ? ./projectName.dhall
-                    }
-            , spec =
-                    argocd.ProjectSpec.default
-                //  { description =
-                        "ArgoCD Example Project"
-                    , sourceRepos =
-                        [   ./repo.dhall sha256:d6ee23f065555c0ad8a59cfeaf0d06f5b2f030a1bf91960c50a66e31937bcb74
-                          ? ./repo.dhall
-                        ]
-                    , destinations =
-                        [   ./destination.dhall sha256:c42b35050c674d39753b5f45d211bf5aef40f0bcd0d73f8d1d7f0046fb668a2d
-                          ? ./destination.dhall
-                        ]
-                    }
-            }
-      )
+      argocd.Project::{
+      , metadata =
+              k8s.defaults.ObjectMeta
+          //  { name =
+                    ./projectName.dhall sha256:d7e4e24f5750f02229d03a034faabf0f3378960c20170d83e78ab83c1131aded
+                  ? ./projectName.dhall
+              }
+      , spec =
+          argocd.ProjectSpec::{
+          , description = "ArgoCD Example Project"
+          , sourceRepos =
+              [   ./repo.dhall sha256:d6ee23f065555c0ad8a59cfeaf0d06f5b2f030a1bf91960c50a66e31937bcb74
+                ? ./repo.dhall
+              ]
+          , destinations =
+              [   ./destination.dhall sha256:c42b35050c674d39753b5f45d211bf5aef40f0bcd0d73f8d1d7f0046fb668a2d
+                ? ./destination.dhall
+              ]
+          }
+      }

--- a/kubernetes/argocd/package.dhall
+++ b/kubernetes/argocd/package.dhall
@@ -2,7 +2,7 @@
       ./Application/package.dhall sha256:47bd28e686730591bffb30ddb014ea47470bfd47b2cf3b2aff72fd79167f4089
     ? ./Application/package.dhall
 , ApplicationSpec =
-      ./ApplicationSpec/package.dhall sha256:29e5cc3a22a0e4fd786871d6c285ea7333d9cbef6341d91ba4045491b0bde157
+      ./ApplicationSpec/package.dhall sha256:c048e113b5a4ea3dd4406313697fa405b67a7d536b7ee806633884f0989eedfb
     ? ./ApplicationSpec/package.dhall
 , ClusterResource =
       ./ClusterResource/package.dhall sha256:828ecf9c58164b6b726669656ca2fbd13790dbd31b5a18443f8f09f89a78d875

--- a/kubernetes/package.dhall
+++ b/kubernetes/package.dhall
@@ -8,7 +8,7 @@
       ./k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
     ? ./k8s/package.dhall
 , argocd =
-      ./argocd/package.dhall sha256:b0ee43f5521aa371be2ea6ac13e1a1c85c7f01cec15431ce58ec79fe9f740847
+      ./argocd/package.dhall sha256:e45774280936733937712c177f862b4f0dd007fc583a231f391b5671bee54f57
     ? ./argocd/package.dhall
 , argo =
       ./argo/schemas.dhall sha256:3dd2e0a8f264968fccb2358b799afacd493f205234501820cf5b3e2134ef1704

--- a/package.dhall
+++ b/package.dhall
@@ -1,5 +1,5 @@
 { kubernetes =
-      ./kubernetes/package.dhall sha256:84edcf75c68cd55e1baf208302063bad167d466bc7ef86dbe96f9d3722d59252
+      ./kubernetes/package.dhall sha256:920cbafcb94f3d3f79548f42c07c3ece0e51d11990dcd92b82b45b4b938b8c7d
     ? ./kubernetes/package.dhall
 , Prelude =
       https://prelude.dhall-lang.org/v11.1.0/package.dhall sha256:99462c205117931c0919f155a6046aec140c70fb8876d208c7c77027ab19c2fa


### PR DESCRIPTION
This adds a default `ignoreDifferences` to the argocd application spec and updates the example to show the new dhall `::` operator syntax