### PR TITLE
Fix mapping resource

### DIFF
--- a/kubernetes/ambassador/Mapping/Type.dhall
+++ b/kubernetes/ambassador/Mapping/Type.dhall
@@ -6,10 +6,12 @@ let Map =
         https://prelude.dhall-lang.org/v11.1.0/Map/Type sha256:210c7a9eba71efbb0f7a66b3dcf8b9d3976ffc2bc0e907aadfb6aa29c333e8ed
       ? https://prelude.dhall-lang.org/v11.1.0/Map/Type
 
+let k8s = ../../k8s/package.dhall
+
 in  { apiVersion :
         Text
     , kind : Text
-    , name : Text
+    , metadata : k8s.types.ObjectMeta
     , prefix : Text
     , service : Text
     , add_linkerd_headers : Optional Bool


### PR DESCRIPTION
This fixes the `Mapping` resource for Ambassador.
These bindings will support only standalone mappings, and not yaml-in-yaml mappings for now (as dhall doesn't have yet the capability of rendering yaml inside another expression (only JSON).