### PR TITLE
Argo workflow defaults

### DIFF
--- a/kubernetes/argo/defaults.dhall
+++ b/kubernetes/argo/defaults.dhall
@@ -92,10 +92,10 @@
       ./defaults/io.argoproj.workflow.v1alpha1.ValueFrom.dhall sha256:555180487c64ec519a9edfab1ecbf4a9ace197e6b781029b2fad639658ec0bd6
     ? ./defaults/io.argoproj.workflow.v1alpha1.ValueFrom.dhall
 , Workflow =
-      ./defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:b9cf5c57462ff2398c2611de50ff3261730a753576aae348b75262519cfb2735
+      ./defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:f4b4f3353829b867084128b99c102bbeb5a2b621fd9a106ba84b2b3f0c2505ea
     ? ./defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall
 , WorkflowList =
-      ./defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:0137972872135ae63d878cfdd672c184081196d2689dd9df5a9d2a5009a3951b
+      ./defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:22da1e7f5446e52ce5812d311ee47c0aa9580834353eb88342c3577e7fce0609
     ? ./defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
 , WorkflowSpec =
       ./defaults/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:23fed14b3cc7b68662d60c24fae28a2d60b5333a25eb66bb3d62d56090ffccfd

--- a/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall
+++ b/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall
@@ -1,4 +1,6 @@
-{ spec =
+{ apiVersion = "argoproj.io/v1alpha1"
+, kind = "Workflow"
+, spec =
       ./io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:23fed14b3cc7b68662d60c24fae28a2d60b5333a25eb66bb3d62d56090ffccfd
     ? ./io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
 }

--- a/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
+++ b/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
@@ -1,4 +1,6 @@
-{ items =
+{ apiVersion = "argoproj.io/v1alpha1"
+, kind = "WorkflowList"
+, items =
     [] : List
            (   ./../types/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:f3a816e0be2f93d473718234a7a513f7c98d04545a27c2d23c95fceefa7fce86
              ? ./../types/io.argoproj.workflow.v1alpha1.Workflow.dhall

--- a/kubernetes/argo/schemas.dhall
+++ b/kubernetes/argo/schemas.dhall
@@ -92,10 +92,10 @@
       ./schemas/io.argoproj.workflow.v1alpha1.ValueFrom.dhall sha256:ae8f89b0fb93156550239aa72d260550c52264946526edb28228d73f5abe8a81
     ? ./schemas/io.argoproj.workflow.v1alpha1.ValueFrom.dhall
 , Workflow =
-      ./schemas/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:7b27f1c1fdaa85beb971bb8a345d3cb934ecc072325b8a9817039c14869377a3
+      ./schemas/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:1f953af8a904136c19a6edd0a655018650fc723ad5bddf7e623c7c094395a0e9
     ? ./schemas/io.argoproj.workflow.v1alpha1.Workflow.dhall
 , WorkflowList =
-      ./schemas/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:369229a051dadf286f2b5c587548a2ae5f301ba1eec11d78daa5f24a51da337d
+      ./schemas/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:ea2e28931cb7ed9d0e88a9483f3007c47ae587364d697ceba406117b9f79bf3d
     ? ./schemas/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
 , WorkflowSpec =
       ./schemas/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:ac1866d5f2a4c1c297934a3c5a87e3f6e15705cc0d57c086cfc860aca3b1bafb

--- a/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.Workflow.dhall
+++ b/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.Workflow.dhall
@@ -2,6 +2,6 @@
       ./../types/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:f3a816e0be2f93d473718234a7a513f7c98d04545a27c2d23c95fceefa7fce86
     ? ./../types/io.argoproj.workflow.v1alpha1.Workflow.dhall
 , default =
-      ./../defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:b9cf5c57462ff2398c2611de50ff3261730a753576aae348b75262519cfb2735
+      ./../defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:f4b4f3353829b867084128b99c102bbeb5a2b621fd9a106ba84b2b3f0c2505ea
     ? ./../defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall
 }

--- a/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
+++ b/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
@@ -2,6 +2,6 @@
       ./../types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:d129a0637d44d12aa279f98568efa9dd5cda3f4fcdd78090881120a8230f2314
     ? ./../types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
 , default =
-      ./../defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:0137972872135ae63d878cfdd672c184081196d2689dd9df5a9d2a5009a3951b
+      ./../defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:22da1e7f5446e52ce5812d311ee47c0aa9580834353eb88342c3577e7fce0609
     ? ./../defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
 }

--- a/kubernetes/package.dhall
+++ b/kubernetes/package.dhall
@@ -11,7 +11,7 @@
       ./argocd/package.dhall sha256:e45774280936733937712c177f862b4f0dd007fc583a231f391b5671bee54f57
     ? ./argocd/package.dhall
 , argo =
-      ./argo/schemas.dhall sha256:3dd2e0a8f264968fccb2358b799afacd493f205234501820cf5b3e2134ef1704
+      ./argo/schemas.dhall sha256:0b2f1fd43591a5f4df3156179f601fbea9adc86c740becf5629570bf82a8874e
     ? ./argo/schemas.dhall
 , ambassador =
       ./ambassador/package.dhall sha256:7c482aa11b7c7d4679e0a8914b89f4c4e07c5b6b70ce961a87082f63f3833c75

--- a/package.dhall
+++ b/package.dhall
@@ -1,5 +1,5 @@
 { kubernetes =
-      ./kubernetes/package.dhall sha256:c90dd618cf536182a0df307c7adce3cf3e9c7598a4a32e85818893a1259d1b96
+      ./kubernetes/package.dhall sha256:476103d139cccb5b56e63c283b450f6ffa210d921fbec4b71f07226183919f0a
     ? ./kubernetes/package.dhall
 , Prelude =
       https://prelude.dhall-lang.org/v11.1.0/package.dhall sha256:99462c205117931c0919f155a6046aec140c70fb8876d208c7c77027ab19c2fa

--- a/scripts/freeze.sh
+++ b/scripts/freeze.sh
@@ -1,4 +1,4 @@
-for file in $(find . -name '*.dhall'); do
+for file in $(find . -name '*.dhall' -print | perl -n -e '$x = $_; $x =~ tr%/%%cd; print length($x), " $_";' | sort -rn -k 1 | awk '{print $2}'); do
     echo "${file}"
 
     dhall --ascii freeze --all --cache --inplace "${file}"


### PR DESCRIPTION
Also has a cheeky fix for freeze script to do freezing in directory depth order, 
so `./package.dhall` gets frozen after `kubernetes/package.dhall` which is after kubernetes/argo/package.dhall etc.  Still not perfect but helps a bit.


