### PR TITLE
Update dhall-kubernetes version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ let packages = https://raw.githubusercontent.com/EarnestResearch/dhall-packages/
 
 let argocd = packages.kubernetes.argocd
 
-let k8s = packages.kubernetes.k8s
+let k8s = packages.kubernetes.k8s.schemas
 
 in  argocd.Application::{
-    , metadata = k8s.defaults.ObjectMeta // { name = "hello-app" }
+    , metadata = k8s.ObjectMeta::{ name = "hello-app" }
     , spec =
         argocd.ApplicationSpec::{
         , project = "hello-project"

--- a/kubernetes/ambassador/AuthService/Type.dhall
+++ b/kubernetes/ambassador/AuthService/Type.dhall
@@ -4,7 +4,7 @@
 -}
 
 let k8s =
-        ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+        ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
       ? ../../k8s/package.dhall
 
 in  { apiVersion :

--- a/kubernetes/ambassador/Mapping/Type.dhall
+++ b/kubernetes/ambassador/Mapping/Type.dhall
@@ -5,7 +5,7 @@
 -}
 
 let k8s =
-        ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+        ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
       ? ../../k8s/package.dhall
 
 in  { apiVersion :

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Affinity.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Affinity.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.Affinity

--- a/kubernetes/argo/types/io.k8s.api.core.v1.ConfigMapKeySelector.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.ConfigMapKeySelector.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.ConfigMapKeySelector

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Container.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Container.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.Container

--- a/kubernetes/argo/types/io.k8s.api.core.v1.ContainerPort.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.ContainerPort.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.ContainerPort

--- a/kubernetes/argo/types/io.k8s.api.core.v1.EnvFromSource.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.EnvFromSource.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.EnvFromSource

--- a/kubernetes/argo/types/io.k8s.api.core.v1.EnvVar.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.EnvVar.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.EnvVar

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Lifecycle.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Lifecycle.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.Lifecycle

--- a/kubernetes/argo/types/io.k8s.api.core.v1.LocalObjectReference.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.LocalObjectReference.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.LocalObjectReference

--- a/kubernetes/argo/types/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.PersistentVolumeClaim

--- a/kubernetes/argo/types/io.k8s.api.core.v1.PodDNSConfig.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.PodDNSConfig.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.PodDNSConfig

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Probe.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Probe.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.Probe

--- a/kubernetes/argo/types/io.k8s.api.core.v1.ResourceRequirements.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.ResourceRequirements.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.ResourceRequirements

--- a/kubernetes/argo/types/io.k8s.api.core.v1.SecretKeySelector.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.SecretKeySelector.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.SecretKeySelector

--- a/kubernetes/argo/types/io.k8s.api.core.v1.SecurityContext.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.SecurityContext.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.SecurityContext

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Toleration.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Toleration.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.Toleration

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Volume.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Volume.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.Volume

--- a/kubernetes/argo/types/io.k8s.api.core.v1.VolumeDevice.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.VolumeDevice.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.VolumeDevice

--- a/kubernetes/argo/types/io.k8s.api.core.v1.VolumeMount.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.VolumeMount.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.VolumeMount

--- a/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta.dhall
+++ b/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.ListMeta

--- a/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+++ b/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
   ? ../../k8s/package.dhall
 ).types.ObjectMeta

--- a/kubernetes/argocd/example/project.dhall
+++ b/kubernetes/argocd/example/project.dhall
@@ -3,17 +3,17 @@ let argocd =
       ? ../package.dhall
 
 let k8s =
-        ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+        ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
       ? ../../k8s/package.dhall
 
 in  argocd.TypesUnion.Project
       argocd.Project::{
       , metadata =
-              k8s.defaults.ObjectMeta
-          //  { name =
-                    ./projectName.dhall sha256:d7e4e24f5750f02229d03a034faabf0f3378960c20170d83e78ab83c1131aded
-                  ? ./projectName.dhall
-              }
+          k8s.schemas.ObjectMeta::{
+          , name =
+                ./projectName.dhall sha256:d7e4e24f5750f02229d03a034faabf0f3378960c20170d83e78ab83c1131aded
+              ? ./projectName.dhall
+          }
       , spec =
           argocd.ProjectSpec::{
           , description = "ArgoCD Example Project"

--- a/kubernetes/argocd/util/internal/makeDhallApp.dhall
+++ b/kubernetes/argocd/util/internal/makeDhallApp.dhall
@@ -29,7 +29,7 @@ let PluginSpec =
       ? ../../PluginSpec/package.dhall
 
 let k8s =
-        ../../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+        ../../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
       ? ../../../k8s/package.dhall
 
 in      \ ( appConfig
@@ -37,30 +37,26 @@ in      \ ( appConfig
             ? ../DhallAppConfig/Type.dhall
           )
     ->    TypesUnion.Application
-            (     Application.default
-              //  { metadata =
-                      k8s.defaults.ObjectMeta // { name = appConfig.name }
-                  , spec =
-                          ApplicationSpec.default
-                      //  { project = appConfig.project
-                          , source =
-                              SourceSpec.TypesUnion.Plugin
-                                (     PluginSourceSpec.default
-                                  //  { repoURL = appConfig.source.url
-                                      , path = appConfig.source.path
-                                      , targetRevision =
-                                          appConfig.source.targetRevision
-                                      , plugin =
-                                              PluginSpec.default
-                                          //  { name = "dhall-to-yaml"
-                                              , env = Some appConfig.parameters
-                                              }
-                                      }
-                                )
-                          , destination = appConfig.destination
-                          , syncPolicy = appConfig.syncPolicy
-                          , ignoreDifferences = Some appConfig.ignoreDifferences
+            Application::{
+            , metadata = k8s.schemas.ObjectMeta::{ name = appConfig.name }
+            , spec =
+                ApplicationSpec::{
+                , project = appConfig.project
+                , source =
+                    SourceSpec.TypesUnion.Plugin
+                      PluginSourceSpec::{
+                      , repoURL = appConfig.source.url
+                      , path = appConfig.source.path
+                      , targetRevision = appConfig.source.targetRevision
+                      , plugin =
+                          PluginSpec::{
+                          , name = "dhall-to-yaml"
+                          , env = Some appConfig.parameters
                           }
-                  }
-            )
+                      }
+                , destination = appConfig.destination
+                , syncPolicy = appConfig.syncPolicy
+                , ignoreDifferences = Some appConfig.ignoreDifferences
+                }
+            }
         : TypesUnion

--- a/kubernetes/argocd/util/internal/makeHelmApp.dhall
+++ b/kubernetes/argocd/util/internal/makeHelmApp.dhall
@@ -23,7 +23,7 @@ let HelmSpec =
       ? ../../HelmSpec/package.dhall
 
 let k8s =
-        ../../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+        ../../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
       ? ../../../k8s/package.dhall
 
 in      \ ( appConfig
@@ -31,32 +31,26 @@ in      \ ( appConfig
             ? ../HelmAppConfig/Type.dhall
           )
     ->    TypesUnion.Application
-            (     Application.default
-              //  { metadata =
-                      k8s.defaults.ObjectMeta // { name = appConfig.name }
-                  , spec =
-                          ApplicationSpec.default
-                      //  { project = appConfig.project
-                          , source =
-                              SourceSpec.TypesUnion.Helm
-                                (     HelmSourceSpec.default
-                                  //  { repoURL = appConfig.source.url
-                                      , path = appConfig.source.path
-                                      , targetRevision =
-                                          appConfig.source.targetRevision
-                                      , helm =
-                                              HelmSpec.default
-                                          //  { valueFiles =
-                                                  Some appConfig.valueFiles
-                                              , parameters =
-                                                  Some appConfig.parameters
-                                              }
-                                      }
-                                )
-                          , destination = appConfig.destination
-                          , syncPolicy = appConfig.syncPolicy
-                          , ignoreDifferences = Some appConfig.ignoreDifferences
+            Application::{
+            , metadata = k8s.schemas.ObjectMeta::{ name = appConfig.name }
+            , spec =
+                ApplicationSpec::{
+                , project = appConfig.project
+                , source =
+                    SourceSpec.TypesUnion.Helm
+                      HelmSourceSpec::{
+                      , repoURL = appConfig.source.url
+                      , path = appConfig.source.path
+                      , targetRevision = appConfig.source.targetRevision
+                      , helm =
+                          HelmSpec::{
+                          , valueFiles = Some appConfig.valueFiles
+                          , parameters = Some appConfig.parameters
                           }
-                  }
-            )
+                      }
+                , destination = appConfig.destination
+                , syncPolicy = appConfig.syncPolicy
+                , ignoreDifferences = Some appConfig.ignoreDifferences
+                }
+            }
         : TypesUnion

--- a/kubernetes/argocd/util/internal/makeKustomizeApp.dhall
+++ b/kubernetes/argocd/util/internal/makeKustomizeApp.dhall
@@ -23,7 +23,7 @@ let KustomizeSpec =
       ? ../../KustomizeSpec/package.dhall
 
 let k8s =
-        ../../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+        ../../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
       ? ../../../k8s/package.dhall
 
 in      \ ( appConfig
@@ -31,33 +31,27 @@ in      \ ( appConfig
             ? ../KustomizeAppConfig/Type.dhall
           )
     ->    TypesUnion.Application
-            (     Application.default
-              //  { metadata =
-                      k8s.defaults.ObjectMeta // { name = appConfig.name }
-                  , spec =
-                          ApplicationSpec.default
-                      //  { project = appConfig.project
-                          , source =
-                              SourceSpec.TypesUnion.Kustomize
-                                (     KustomizeSourceSpec.default
-                                  //  { repoURL = appConfig.source.url
-                                      , path = appConfig.source.path
-                                      , targetRevision =
-                                          appConfig.source.targetRevision
-                                      , kustomize =
-                                              KustomizeSpec.default
-                                          //  { commonLabels =
-                                                  appConfig.commonLabels
-                                              , images = appConfig.images
-                                              , namePrefix =
-                                                  appConfig.namePrefix
-                                              }
-                                      }
-                                )
-                          , destination = appConfig.destination
-                          , syncPolicy = appConfig.syncPolicy
-                          , ignoreDifferences = Some appConfig.ignoreDifferences
+            Application::{
+            , metadata = k8s.schemas.ObjectMeta::{ name = appConfig.name }
+            , spec =
+                ApplicationSpec::{
+                , project = appConfig.project
+                , source =
+                    SourceSpec.TypesUnion.Kustomize
+                      KustomizeSourceSpec::{
+                      , repoURL = appConfig.source.url
+                      , path = appConfig.source.path
+                      , targetRevision = appConfig.source.targetRevision
+                      , kustomize =
+                          KustomizeSpec::{
+                          , commonLabels = appConfig.commonLabels
+                          , images = appConfig.images
+                          , namePrefix = appConfig.namePrefix
                           }
-                  }
-            )
+                      }
+                , destination = appConfig.destination
+                , syncPolicy = appConfig.syncPolicy
+                , ignoreDifferences = Some appConfig.ignoreDifferences
+                }
+            }
         : TypesUnion

--- a/kubernetes/argocd/util/withSyncWave.dhall
+++ b/kubernetes/argocd/util/withSyncWave.dhall
@@ -2,7 +2,7 @@
     Utility to add sync waves to argocd applications and projects.
 -}
 let k8s =
-        ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+        ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
       ? ../../k8s/package.dhall
 
 let Project =

--- a/kubernetes/cert-manager/Certificate/Type.dhall
+++ b/kubernetes/cert-manager/Certificate/Type.dhall
@@ -1,5 +1,5 @@
 let k8s =
-        ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+        ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
       ? ../../k8s/package.dhall
 
 in  { apiVersion :

--- a/kubernetes/cert-manager/ClusterIssuer/Type.dhall
+++ b/kubernetes/cert-manager/ClusterIssuer/Type.dhall
@@ -1,5 +1,5 @@
 let k8s =
-        ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+        ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
       ? ../../k8s/package.dhall
 
 in  { apiVersion : Text

--- a/kubernetes/k8s/package.dhall
+++ b/kubernetes/k8s/package.dhall
@@ -1,7 +1,9 @@
 { defaults =
-    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/4ad58156b7fdbbb6da0543d8b314df899feca077/defaults.dhall sha256:4450e23dc81975d111650e06c0238862944bf699537af6cbacac9c7e471dfabe
+    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/defaults.dhall sha256:98bf62170e7785da6f627a06980c5788a5b8bdd0d1e61bb7c141beef18a3129c
 , types =
-    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/4ad58156b7fdbbb6da0543d8b314df899feca077/types.dhall sha256:e48e21b807dad217a6c3e631fcaf3e950062310bfb4a8bbcecc330eb7b2f60ed
+    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/types.dhall sha256:e48e21b807dad217a6c3e631fcaf3e950062310bfb4a8bbcecc330eb7b2f60ed
 , typesUnion =
-    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/4ad58156b7fdbbb6da0543d8b314df899feca077/typesUnion.dhall sha256:8e8db456b218b93f8241d497e54d07214b132523fe84263e6c03496c141a8b18
+    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/typesUnion.dhall sha256:8e8db456b218b93f8241d497e54d07214b132523fe84263e6c03496c141a8b18
+, schemas =
+    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/schemas.dhall sha256:0a362a64a631fe7911f71438fa05acdcdf6469850cce4f910e4cf126315d1011
 }

--- a/kubernetes/kubernetes-external-secrets/ExternalSecret/Type.dhall
+++ b/kubernetes/kubernetes-external-secrets/ExternalSecret/Type.dhall
@@ -1,5 +1,5 @@
 let k8s =
-        ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+        ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
       ? ../../k8s/package.dhall
 
 in  { apiVersion :

--- a/kubernetes/package.dhall
+++ b/kubernetes/package.dhall
@@ -5,7 +5,7 @@
       ./kubernetes-external-secrets/package.dhall sha256:80f9cd5625bf7fa2eb87b67627d712062194a85e1b399f4ed0efa03aaac68b27
     ? ./kubernetes-external-secrets/package.dhall
 , k8s =
-      ./k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
+      ./k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
     ? ./k8s/package.dhall
 , argocd =
       ./argocd/package.dhall sha256:e45774280936733937712c177f862b4f0dd007fc583a231f391b5671bee54f57

--- a/package.dhall
+++ b/package.dhall
@@ -1,5 +1,5 @@
 { kubernetes =
-      ./kubernetes/package.dhall sha256:476103d139cccb5b56e63c283b450f6ffa210d921fbec4b71f07226183919f0a
+      ./kubernetes/package.dhall sha256:80d33906bdb44acb81aad317db22c03b757370dac4389949d135198a3f31224b
     ? ./kubernetes/package.dhall
 , Prelude =
       https://prelude.dhall-lang.org/v11.1.0/package.dhall sha256:99462c205117931c0919f155a6046aec140c70fb8876d208c7c77027ab19c2fa

--- a/src/kubernetes/argocd/example/project.dhall
+++ b/src/kubernetes/argocd/example/project.dhall
@@ -4,7 +4,7 @@ let k8s = ../../k8s/package.dhall
 
 in  argocd.TypesUnion.Project
       argocd.Project::{
-      , metadata = k8s.defaults.ObjectMeta // { name = ./projectName.dhall }
+      , metadata = k8s.schemas.ObjectMeta::{ name = ./projectName.dhall }
       , spec =
           argocd.ProjectSpec::{
           , description = "ArgoCD Example Project"

--- a/src/kubernetes/argocd/util/internal/makeDhallApp.dhall
+++ b/src/kubernetes/argocd/util/internal/makeDhallApp.dhall
@@ -20,30 +20,26 @@ let k8s = ../../../k8s/package.dhall
 
 in      \(appConfig : ../DhallAppConfig/Type.dhall)
     ->    TypesUnion.Application
-            (     Application.default
-              //  { metadata =
-                      k8s.defaults.ObjectMeta // { name = appConfig.name }
-                  , spec =
-                          ApplicationSpec.default
-                      //  { project = appConfig.project
-                          , source =
-                              SourceSpec.TypesUnion.Plugin
-                                (     PluginSourceSpec.default
-                                  //  { repoURL = appConfig.source.url
-                                      , path = appConfig.source.path
-                                      , targetRevision =
-                                          appConfig.source.targetRevision
-                                      , plugin =
-                                              PluginSpec.default
-                                          //  { name = "dhall-to-yaml"
-                                              , env = Some appConfig.parameters
-                                              }
-                                      }
-                                )
-                          , destination = appConfig.destination
-                          , syncPolicy = appConfig.syncPolicy
-                          , ignoreDifferences = Some appConfig.ignoreDifferences
+            Application::{
+            , metadata = k8s.schemas.ObjectMeta::{ name = appConfig.name }
+            , spec =
+                ApplicationSpec::{
+                , project = appConfig.project
+                , source =
+                    SourceSpec.TypesUnion.Plugin
+                      PluginSourceSpec::{
+                      , repoURL = appConfig.source.url
+                      , path = appConfig.source.path
+                      , targetRevision = appConfig.source.targetRevision
+                      , plugin =
+                          PluginSpec::{
+                          , name = "dhall-to-yaml"
+                          , env = Some appConfig.parameters
                           }
-                  }
-            )
+                      }
+                , destination = appConfig.destination
+                , syncPolicy = appConfig.syncPolicy
+                , ignoreDifferences = Some appConfig.ignoreDifferences
+                }
+            }
         : TypesUnion

--- a/src/kubernetes/argocd/util/internal/makeHelmApp.dhall
+++ b/src/kubernetes/argocd/util/internal/makeHelmApp.dhall
@@ -14,32 +14,26 @@ let k8s = ../../../k8s/package.dhall
 
 in      \(appConfig : ../HelmAppConfig/Type.dhall)
     ->    TypesUnion.Application
-            (     Application.default
-              //  { metadata =
-                      k8s.defaults.ObjectMeta // { name = appConfig.name }
-                  , spec =
-                          ApplicationSpec.default
-                      //  { project = appConfig.project
-                          , source =
-                              SourceSpec.TypesUnion.Helm
-                                (     HelmSourceSpec.default
-                                  //  { repoURL = appConfig.source.url
-                                      , path = appConfig.source.path
-                                      , targetRevision =
-                                          appConfig.source.targetRevision
-                                      , helm =
-                                              HelmSpec.default
-                                          //  { valueFiles =
-                                                  Some appConfig.valueFiles
-                                              , parameters =
-                                                  Some appConfig.parameters
-                                              }
-                                      }
-                                )
-                          , destination = appConfig.destination
-                          , syncPolicy = appConfig.syncPolicy
-                          , ignoreDifferences = Some appConfig.ignoreDifferences
+            Application::{
+            , metadata = k8s.schemas.ObjectMeta::{ name = appConfig.name }
+            , spec =
+                ApplicationSpec::{
+                , project = appConfig.project
+                , source =
+                    SourceSpec.TypesUnion.Helm
+                      HelmSourceSpec::{
+                      , repoURL = appConfig.source.url
+                      , path = appConfig.source.path
+                      , targetRevision = appConfig.source.targetRevision
+                      , helm =
+                          HelmSpec::{
+                          , valueFiles = Some appConfig.valueFiles
+                          , parameters = Some appConfig.parameters
                           }
-                  }
-            )
+                      }
+                , destination = appConfig.destination
+                , syncPolicy = appConfig.syncPolicy
+                , ignoreDifferences = Some appConfig.ignoreDifferences
+                }
+            }
         : TypesUnion

--- a/src/kubernetes/argocd/util/internal/makeKustomizeApp.dhall
+++ b/src/kubernetes/argocd/util/internal/makeKustomizeApp.dhall
@@ -14,33 +14,27 @@ let k8s = ../../../k8s/package.dhall
 
 in      \(appConfig : ../KustomizeAppConfig/Type.dhall)
     ->    TypesUnion.Application
-            (     Application.default
-              //  { metadata =
-                      k8s.defaults.ObjectMeta // { name = appConfig.name }
-                  , spec =
-                          ApplicationSpec.default
-                      //  { project = appConfig.project
-                          , source =
-                              SourceSpec.TypesUnion.Kustomize
-                                (     KustomizeSourceSpec.default
-                                  //  { repoURL = appConfig.source.url
-                                      , path = appConfig.source.path
-                                      , targetRevision =
-                                          appConfig.source.targetRevision
-                                      , kustomize =
-                                              KustomizeSpec.default
-                                          //  { commonLabels =
-                                                  appConfig.commonLabels
-                                              , images = appConfig.images
-                                              , namePrefix =
-                                                  appConfig.namePrefix
-                                              }
-                                      }
-                                )
-                          , destination = appConfig.destination
-                          , syncPolicy = appConfig.syncPolicy
-                          , ignoreDifferences = Some appConfig.ignoreDifferences
+            Application::{
+            , metadata = k8s.schemas.ObjectMeta::{ name = appConfig.name }
+            , spec =
+                ApplicationSpec::{
+                , project = appConfig.project
+                , source =
+                    SourceSpec.TypesUnion.Kustomize
+                      KustomizeSourceSpec::{
+                      , repoURL = appConfig.source.url
+                      , path = appConfig.source.path
+                      , targetRevision = appConfig.source.targetRevision
+                      , kustomize =
+                          KustomizeSpec::{
+                          , commonLabels = appConfig.commonLabels
+                          , images = appConfig.images
+                          , namePrefix = appConfig.namePrefix
                           }
-                  }
-            )
+                      }
+                , destination = appConfig.destination
+                , syncPolicy = appConfig.syncPolicy
+                , ignoreDifferences = Some appConfig.ignoreDifferences
+                }
+            }
         : TypesUnion

--- a/src/kubernetes/k8s/package.dhall
+++ b/src/kubernetes/k8s/package.dhall
@@ -1,7 +1,9 @@
 { defaults =
-    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/4ad58156b7fdbbb6da0543d8b314df899feca077/defaults.dhall sha256:4450e23dc81975d111650e06c0238862944bf699537af6cbacac9c7e471dfabe
+    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/defaults.dhall sha256:98bf62170e7785da6f627a06980c5788a5b8bdd0d1e61bb7c141beef18a3129c
 , types =
-    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/4ad58156b7fdbbb6da0543d8b314df899feca077/types.dhall sha256:e48e21b807dad217a6c3e631fcaf3e950062310bfb4a8bbcecc330eb7b2f60ed
+    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/types.dhall sha256:e48e21b807dad217a6c3e631fcaf3e950062310bfb4a8bbcecc330eb7b2f60ed
 , typesUnion =
-    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/4ad58156b7fdbbb6da0543d8b314df899feca077/typesUnion.dhall sha256:8e8db456b218b93f8241d497e54d07214b132523fe84263e6c03496c141a8b18
+    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/typesUnion.dhall sha256:8e8db456b218b93f8241d497e54d07214b132523fe84263e6c03496c141a8b18
+, schemas =
+    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/schemas.dhall sha256:0a362a64a631fe7911f71438fa05acdcdf6469850cce4f910e4cf126315d1011
 }


### PR DESCRIPTION
This updates the `dhall-kubernetes` version to the latest, which finally supports the `schemas` (record completion operator syntax).