### PR TITLE
sane defaults for argo-events

### DIFF
--- a/kubernetes/argo-events/defaults.dhall
+++ b/kubernetes/argo-events/defaults.dhall
@@ -5,7 +5,7 @@
       ./defaults/io.argoproj.common.EventContext.dhall sha256:249fd30975e15f45351d054cdcca8ed4fb264e8d3fe43a857f6637bb82080b7a
     ? ./defaults/io.argoproj.common.EventContext.dhall
 , EventProtocol =
-      ./defaults/io.argoproj.common.EventProtocol.dhall sha256:595717e9898866ffc565bbba97992241804679d9af1b2ae7240eb92edafb4377
+      ./defaults/io.argoproj.common.EventProtocol.dhall sha256:65823d7a1d46ecb511dc3e55892be011e726346b6b7a436258d783490b36ba5a
     ? ./defaults/io.argoproj.common.EventProtocol.dhall
 , Http =
       ./defaults/io.argoproj.common.Http.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
@@ -29,16 +29,16 @@
       ./defaults/io.argoproj.common.URI.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
     ? ./defaults/io.argoproj.common.URI.dhall
 , Gateway =
-      ./defaults/io.argoproj.gateway.v1alpha1.Gateway.dhall sha256:8c5173622a53c1c96cbc7d81a25850ca26a7a006443599d3ef7459a257aad754
+      ./defaults/io.argoproj.gateway.v1alpha1.Gateway.dhall sha256:5bbf5dd600bc192950a95ff043d4b4e58975ffbf3352514a9c095dfae15a5321
     ? ./defaults/io.argoproj.gateway.v1alpha1.Gateway.dhall
 , GatewayList =
-      ./defaults/io.argoproj.gateway.v1alpha1.GatewayList.dhall sha256:96a6c5cb95450e19e7c808deac66afa1224795ec16b6b2ca4787a6514f4d0536
+      ./defaults/io.argoproj.gateway.v1alpha1.GatewayList.dhall sha256:60aafe16c9922a28918284b77bffe37aac4646afd831936ab3233fb5f8d9d640
     ? ./defaults/io.argoproj.gateway.v1alpha1.GatewayList.dhall
 , GatewayNotificationWatcher =
       ./defaults/io.argoproj.gateway.v1alpha1.GatewayNotificationWatcher.dhall sha256:ffe97f63e5bc2a49da3738cfabf980f1cfed5d0df38c2d9c37f7e7b43caddf9e
     ? ./defaults/io.argoproj.gateway.v1alpha1.GatewayNotificationWatcher.dhall
 , GatewaySpec =
-      ./defaults/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall sha256:128ac3e5d79c499300f775399bc169d907dca8ac0fd2ef5abad81785e903e296
+      ./defaults/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall sha256:61e874bcd031ed04e2eec8184a6a8130fef3ca0687785a81dd9b92c0dd29c7a2
     ? ./defaults/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall
 , GatewayStatus =
       ./defaults/io.argoproj.gateway.v1alpha1.GatewayStatus.dhall sha256:ba4a4f9c5d5e54b27331ae0cd65231690118b797c19754adb6ba780ea3f02354
@@ -65,10 +65,10 @@
       ./defaults/io.argoproj.sensor.v1alpha1.DependencyGroup.dhall sha256:6bb64768081e4095eeb17757a1bb5843da2eb6e07ab036f7fb4b7d8de90f64bd
     ? ./defaults/io.argoproj.sensor.v1alpha1.DependencyGroup.dhall
 , EventDependency =
-      ./defaults/io.argoproj.sensor.v1alpha1.EventDependency.dhall sha256:5bd22a999bc5e22cdbd16b5ae679b12ef15493144a1c1aa1f77712129518da3b
+      ./defaults/io.argoproj.sensor.v1alpha1.EventDependency.dhall sha256:3a91f3a97ce99eb211e54c7b74eb56f05c0bcd85c9ccdbd6d90dacf0f90484c3
     ? ./defaults/io.argoproj.sensor.v1alpha1.EventDependency.dhall
 , EventDependencyFilter =
-      ./defaults/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall sha256:d246d77f397c20815b1a74318ff35c9ca14d4a2a42aac00570424886d1bd46eb
+      ./defaults/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall sha256:38fa3ee91e63c594cd6aa8eafd9159472380b45f70474cfb271ecc06d40b0979
     ? ./defaults/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall
 , FileArtifact =
       ./defaults/io.argoproj.sensor.v1alpha1.FileArtifact.dhall sha256:c3720062b9d3e2f4e6da3f1ca38f284725a2f80cdbcf01bf4538449121714abf
@@ -83,13 +83,13 @@
       ./defaults/io.argoproj.sensor.v1alpha1.GitRemoteConfig.dhall sha256:8000f8ee7cb045d64c704fbc640994ca0f0ccf3abae84701a77b94d44bea06c8
     ? ./defaults/io.argoproj.sensor.v1alpha1.GitRemoteConfig.dhall
 , Sensor =
-      ./defaults/io.argoproj.sensor.v1alpha1.Sensor.dhall sha256:9c9d8e8d1c1615b676e7ded7680cd3b3dbf37bb168b19d74ee4ff6d83cd95ea5
+      ./defaults/io.argoproj.sensor.v1alpha1.Sensor.dhall sha256:57720130c88127c6cdb70df702be5fd27b6b5b09cab9a29c30e470eac1a62668
     ? ./defaults/io.argoproj.sensor.v1alpha1.Sensor.dhall
 , SensorList =
-      ./defaults/io.argoproj.sensor.v1alpha1.SensorList.dhall sha256:58edad8bc62f024a186adb8675c767935cdc6bcdf66356b0e2fd72791ee61d41
+      ./defaults/io.argoproj.sensor.v1alpha1.SensorList.dhall sha256:e6f1134688b164d76ba1997ddb61773d276fb5dd308313ed4965669fd1e1fc06
     ? ./defaults/io.argoproj.sensor.v1alpha1.SensorList.dhall
 , SensorSpec =
-      ./defaults/io.argoproj.sensor.v1alpha1.SensorSpec.dhall sha256:6fbaa758420f8c09c0aadc40a2556d96c1614aa46e130a4ccfa71df4974281aa
+      ./defaults/io.argoproj.sensor.v1alpha1.SensorSpec.dhall sha256:e3462106e552d0d338751b4defdb77d8665d453623666d3f1a77e7d984f2adbf
     ? ./defaults/io.argoproj.sensor.v1alpha1.SensorSpec.dhall
 , SensorStatus =
       ./defaults/io.argoproj.sensor.v1alpha1.SensorStatus.dhall sha256:59051ce560a6037df40185235ededfa2ac4ff759b9000b2a6e60912a2b1af9f7
@@ -98,7 +98,7 @@
       ./defaults/io.argoproj.sensor.v1alpha1.TimeFilter.dhall sha256:b5bbef78ff0556b19f97a49f961d3aeb6a1d814357079d35dc2c6041b029f73e
     ? ./defaults/io.argoproj.sensor.v1alpha1.TimeFilter.dhall
 , Trigger =
-      ./defaults/io.argoproj.sensor.v1alpha1.Trigger.dhall sha256:f002b3a5e5458a2d5c718b36927cd20f7b24a0526b28385d50a082d6f05f52d3
+      ./defaults/io.argoproj.sensor.v1alpha1.Trigger.dhall sha256:0fc4f1e2c85a533bcb0ce00418a7d90577729d5fe5dc88d4e7bab95e20f727fd
     ? ./defaults/io.argoproj.sensor.v1alpha1.Trigger.dhall
 , TriggerCondition =
       ./defaults/io.argoproj.sensor.v1alpha1.TriggerCondition.dhall sha256:491674da73da706232edcad38dc05eca28882d2944a4aebcf552cda873ed9564

--- a/kubernetes/argo-events/defaults/io.argoproj.common.EventProtocol.dhall
+++ b/kubernetes/argo-events/defaults/io.argoproj.common.EventProtocol.dhall
@@ -1,7 +1,11 @@
 { http =
-      ./io.argoproj.common.Http.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
-    ? ./io.argoproj.common.Http.dhall
+    None
+      (   ../types/io.argoproj.common.Http.dhall sha256:008bbd365377a850574776abce886a072765a967b876e492c1c51afab13f2e19
+        ? ../types/io.argoproj.common.Http.dhall
+      )
 , nats =
-      ./io.argoproj.common.Nats.dhall sha256:70a1d83d7c4d9313eb7a93bc54e3f76f176fb419b3cd22d1efd05afe6502b852
-    ? ./io.argoproj.common.Nats.dhall
+    None
+      (   ../types/io.argoproj.common.Nats.dhall sha256:ffacddff3a7a785e889ac7c8f70baaeb41172d747f508ccd648239628aa65e3a
+        ? ../types/io.argoproj.common.Nats.dhall
+      )
 }

--- a/kubernetes/argo-events/defaults/io.argoproj.gateway.v1alpha1.Gateway.dhall
+++ b/kubernetes/argo-events/defaults/io.argoproj.gateway.v1alpha1.Gateway.dhall
@@ -1,7 +1,11 @@
 { spec =
-      ./io.argoproj.gateway.v1alpha1.GatewaySpec.dhall sha256:128ac3e5d79c499300f775399bc169d907dca8ac0fd2ef5abad81785e903e296
+      ./io.argoproj.gateway.v1alpha1.GatewaySpec.dhall sha256:61e874bcd031ed04e2eec8184a6a8130fef3ca0687785a81dd9b92c0dd29c7a2
     ? ./io.argoproj.gateway.v1alpha1.GatewaySpec.dhall
 , status =
-      ./io.argoproj.gateway.v1alpha1.GatewayStatus.dhall sha256:ba4a4f9c5d5e54b27331ae0cd65231690118b797c19754adb6ba780ea3f02354
-    ? ./io.argoproj.gateway.v1alpha1.GatewayStatus.dhall
+    None
+      (   ../types/io.argoproj.gateway.v1alpha1.GatewayStatus.dhall sha256:f9c4c6302fdf182c86abc417040942701b3dd7d526105914793262d229398cf5
+        ? ../types/io.argoproj.gateway.v1alpha1.GatewayStatus.dhall
+      )
+, apiVersion = "argoproj.io/v1alpha1"
+, kind = "Gateway"
 }

--- a/kubernetes/argo-events/defaults/io.argoproj.gateway.v1alpha1.GatewayList.dhall
+++ b/kubernetes/argo-events/defaults/io.argoproj.gateway.v1alpha1.GatewayList.dhall
@@ -1,6 +1,8 @@
 { items =
     [] : List
-           (   ./../types/io.argoproj.gateway.v1alpha1.Gateway.dhall sha256:099f71ccd7350834abc4cc7887e10fff3d192cc0598d6e73335606b11691c1d5
+           (   ./../types/io.argoproj.gateway.v1alpha1.Gateway.dhall sha256:eaef66a79ed76dfd4b84726568eacbf64e00e445b12f31d73960f8865676309a
              ? ./../types/io.argoproj.gateway.v1alpha1.Gateway.dhall
            )
+, apiVersion = "argoproj.io/v1alpha1"
+, kind = "GatewayList"
 }

--- a/kubernetes/argo-events/defaults/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall
+++ b/kubernetes/argo-events/defaults/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall
@@ -1,5 +1,5 @@
 { eventProtocol =
-      ./io.argoproj.common.EventProtocol.dhall sha256:595717e9898866ffc565bbba97992241804679d9af1b2ae7240eb92edafb4377
+      ./io.argoproj.common.EventProtocol.dhall sha256:65823d7a1d46ecb511dc3e55892be011e726346b6b7a436258d783490b36ba5a
     ? ./io.argoproj.common.EventProtocol.dhall
 , eventSource = None Text
 , service =

--- a/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.EventDependency.dhall
+++ b/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.EventDependency.dhall
@@ -1,7 +1,7 @@
 { connected = None Bool
 , filters =
     None
-      (   ./../types/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall sha256:9cf11d71d3ba3bb2567725359cc81265335fe484cd130fa212a8ed6619e79799
+      (   ./../types/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall sha256:c7475ea5bb14bb2091202e58125c71ef61cfb292d7e7c17a8a3966ebc747381c
         ? ./../types/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall
       )
 }

--- a/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall
+++ b/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall
@@ -4,8 +4,10 @@
              ? ./../types/io.argoproj.sensor.v1alpha1.DataFilter.dhall
            )
 , time =
-      ./io.argoproj.sensor.v1alpha1.TimeFilter.dhall sha256:b5bbef78ff0556b19f97a49f961d3aeb6a1d814357079d35dc2c6041b029f73e
-    ? ./io.argoproj.sensor.v1alpha1.TimeFilter.dhall
+    None
+      (   ../types/io.argoproj.sensor.v1alpha1.TimeFilter.dhall sha256:08b2e66593f50b2f8d059b80a2fe8b010c866918df8e8f61f5c65eb42061459b
+        ? ../types/io.argoproj.sensor.v1alpha1.TimeFilter.dhall
+      )
 , context =
     None
       (   ./../types/io.argoproj.common.EventContext.dhall sha256:5498b0a1675bbc617e96443115ac9911412a092930feb4e958ef995153fc4a1b

--- a/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.Sensor.dhall
+++ b/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.Sensor.dhall
@@ -1,7 +1,11 @@
 { spec =
-      ./io.argoproj.sensor.v1alpha1.SensorSpec.dhall sha256:6fbaa758420f8c09c0aadc40a2556d96c1614aa46e130a4ccfa71df4974281aa
+      ./io.argoproj.sensor.v1alpha1.SensorSpec.dhall sha256:e3462106e552d0d338751b4defdb77d8665d453623666d3f1a77e7d984f2adbf
     ? ./io.argoproj.sensor.v1alpha1.SensorSpec.dhall
 , status =
-      ./io.argoproj.sensor.v1alpha1.SensorStatus.dhall sha256:59051ce560a6037df40185235ededfa2ac4ff759b9000b2a6e60912a2b1af9f7
-    ? ./io.argoproj.sensor.v1alpha1.SensorStatus.dhall
+    None
+      (   ../types/io.argoproj.sensor.v1alpha1.SensorStatus.dhall sha256:a7a5b93d43239663c5da523754c1a34d8e58172a934370427253c2a96dfc0acc
+        ? ../types/io.argoproj.sensor.v1alpha1.SensorStatus.dhall
+      )
+, apiVersion = "argoproj.io/v1alpha1"
+, kind = "Sensor"
 }

--- a/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.SensorList.dhall
+++ b/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.SensorList.dhall
@@ -1,6 +1,8 @@
 { items =
     [] : List
-           (   ./../types/io.argoproj.sensor.v1alpha1.Sensor.dhall sha256:8c5385fad5951d3806d4efce6c5070ecb86e342a4b5cb4a3bc1a089c7435d4cd
+           (   ./../types/io.argoproj.sensor.v1alpha1.Sensor.dhall sha256:f661ba5469b568558a8666d06891732a7cae9c155c1dc31d5fca54fe5595120b
              ? ./../types/io.argoproj.sensor.v1alpha1.Sensor.dhall
            )
+, apiVersion = "argoproj.io/v1alpha1"
+, kind = "SensorList"
 }

--- a/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.SensorSpec.dhall
+++ b/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.SensorSpec.dhall
@@ -1,6 +1,6 @@
 { dependencies =
     [] : List
-           (   ./../types/io.argoproj.sensor.v1alpha1.EventDependency.dhall sha256:2e475774c543fc6ca35b5874178b42b8676651f39af853dd00ced266b4150a2e
+           (   ./../types/io.argoproj.sensor.v1alpha1.EventDependency.dhall sha256:999968e4fec01dacd5adde195e67ec343538748208cb57d4d0cfa44d097f328e
              ? ./../types/io.argoproj.sensor.v1alpha1.EventDependency.dhall
            )
 , dependencyGroups =
@@ -9,11 +9,11 @@
              ? ./../types/io.argoproj.sensor.v1alpha1.DependencyGroup.dhall
            )
 , eventProtocol =
-      ./io.argoproj.common.EventProtocol.dhall sha256:595717e9898866ffc565bbba97992241804679d9af1b2ae7240eb92edafb4377
+      ./io.argoproj.common.EventProtocol.dhall sha256:65823d7a1d46ecb511dc3e55892be011e726346b6b7a436258d783490b36ba5a
     ? ./io.argoproj.common.EventProtocol.dhall
 , triggers =
     [] : List
-           (   ./../types/io.argoproj.sensor.v1alpha1.Trigger.dhall sha256:ef1d89439d9348e29c0b93fdb4ede786a6b7e6ebcda4cccbaa581f5051f1ee2e
+           (   ./../types/io.argoproj.sensor.v1alpha1.Trigger.dhall sha256:b299619204344298bf28313fd49730e1fe2ed4bcff2e969d44ca70e5a03f950d
              ? ./../types/io.argoproj.sensor.v1alpha1.Trigger.dhall
            )
 , circuit = None Text

--- a/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.Trigger.dhall
+++ b/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.Trigger.dhall
@@ -1,6 +1,8 @@
 { policy =
-      ./io.argoproj.sensor.v1alpha1.TriggerPolicy.dhall sha256:877ac60f91b366bcc7a498cd8e38553a7ed9cd6e9c8e80673e97f455e484815a
-    ? ./io.argoproj.sensor.v1alpha1.TriggerPolicy.dhall
+    None
+      (   ../types/io.argoproj.sensor.v1alpha1.TriggerPolicy.dhall sha256:4368ac346df3a447efddce45d73c3ce2a61b8255757adf6df5d5525a2ee3918b
+        ? ../types/io.argoproj.sensor.v1alpha1.TriggerPolicy.dhall
+      )
 , resourceParameters =
     [] : List
            (   ./../types/io.argoproj.sensor.v1alpha1.TriggerParameter.dhall sha256:8a4ba38bbb1db06cd3aed94150e9c2733d7f3aed016d97d060491fa2f3af6b45

--- a/kubernetes/argo-events/package.dhall
+++ b/kubernetes/argo-events/package.dhall
@@ -1,0 +1,13 @@
+{ defaults =
+      ./defaults.dhall sha256:e1996555a811f29caa92ed7cbb863310fa9401d6bd46fbcfbef3eb162b53f67e
+    ? ./defaults.dhall
+, types =
+      ./types.dhall sha256:d8e9842869effec98be953da2b8307e79f7aea90791b38eca203ef5db7c7a0b5
+    ? ./types.dhall
+, typesUnion =
+      ./typesUnion.dhall sha256:8c23e2f66b1ed58160fe5578128b5a15995c166d5eeed6820a452e611b6ee9fb
+    ? ./typesUnion.dhall
+, schemas =
+      ./schemas.dhall sha256:5e3a55acd379ed2892dee5959c4686353d9aeca00d24e636d5fbe56c0ed29c7f
+    ? ./schemas.dhall
+}

--- a/kubernetes/argo-events/schemas.dhall
+++ b/kubernetes/argo-events/schemas.dhall
@@ -5,7 +5,7 @@
       ./schemas/io.argoproj.common.EventContext.dhall sha256:e13fa48650543999727f1f2c579eb2d17dafc890129a68eccedc72937ce8d4b2
     ? ./schemas/io.argoproj.common.EventContext.dhall
 , EventProtocol =
-      ./schemas/io.argoproj.common.EventProtocol.dhall sha256:1b12b969b92d10cd722ce20ac4f5236d8f431ffac7314408abf23b8f7521f710
+      ./schemas/io.argoproj.common.EventProtocol.dhall sha256:c32ceda3c84602d1a430c34557cafa2b486a65357207dec5a1bfac74c8b2a4d2
     ? ./schemas/io.argoproj.common.EventProtocol.dhall
 , Http =
       ./schemas/io.argoproj.common.Http.dhall sha256:44bd8ed530983c65ab0539f48fb445da28fe5a6966bc65ac34a6a310bc2adda5
@@ -29,16 +29,16 @@
       ./schemas/io.argoproj.common.URI.dhall sha256:68e9157ff2a0393ae5a2a40cface562a64cdcc5e4edc0f04d9f634323b1e82ef
     ? ./schemas/io.argoproj.common.URI.dhall
 , Gateway =
-      ./schemas/io.argoproj.gateway.v1alpha1.Gateway.dhall sha256:05394fb813a30c4eb0bf7471304a27bfe6c6b7b56ff8d9331937fb9628c15e0a
+      ./schemas/io.argoproj.gateway.v1alpha1.Gateway.dhall sha256:f3e3c347bc60e6a14b2cdffa8a4bdce1fe05101565df369392241ae57726f964
     ? ./schemas/io.argoproj.gateway.v1alpha1.Gateway.dhall
 , GatewayList =
-      ./schemas/io.argoproj.gateway.v1alpha1.GatewayList.dhall sha256:77822f04735716793555df2f40c1e8d8dfdadc02d7846a676a771339117b4893
+      ./schemas/io.argoproj.gateway.v1alpha1.GatewayList.dhall sha256:32f77f1738973c1e4b28b6b5c4937e172e19535d745a364bc980f38405f3dab9
     ? ./schemas/io.argoproj.gateway.v1alpha1.GatewayList.dhall
 , GatewayNotificationWatcher =
       ./schemas/io.argoproj.gateway.v1alpha1.GatewayNotificationWatcher.dhall sha256:3ec8964671531a4e385b355eec8db73b1bd4dbd4253fa2fa8c2dd8a2a535a897
     ? ./schemas/io.argoproj.gateway.v1alpha1.GatewayNotificationWatcher.dhall
 , GatewaySpec =
-      ./schemas/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall sha256:4ad6fc05c6c9e66acfc83e2e8bd8479aa4b4709c6978bdad63acbd62d3a7b2a2
+      ./schemas/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall sha256:e71406ee320c688451dc042a0c6b22d999a5e4581507c75f2fcbf4c6bf5d86b9
     ? ./schemas/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall
 , GatewayStatus =
       ./schemas/io.argoproj.gateway.v1alpha1.GatewayStatus.dhall sha256:cb54bb4a9f5e69247dd7970a98ad25606aa334c7df382b97da5f5854553bcacc
@@ -65,10 +65,10 @@
       ./schemas/io.argoproj.sensor.v1alpha1.DependencyGroup.dhall sha256:2b6ca43ad53cac0c898fb6cdf5eec3c7dbe0b2d1a8806a53f1dc6c8163dc8a6e
     ? ./schemas/io.argoproj.sensor.v1alpha1.DependencyGroup.dhall
 , EventDependency =
-      ./schemas/io.argoproj.sensor.v1alpha1.EventDependency.dhall sha256:f15cb90f5c8baf9db1be573412bca6ace6ef88dd004716de726327b3eca93397
+      ./schemas/io.argoproj.sensor.v1alpha1.EventDependency.dhall sha256:cfe7284f984d926e243e37d20fde25d01f015ffbf46d3dc3d72771276d0648cc
     ? ./schemas/io.argoproj.sensor.v1alpha1.EventDependency.dhall
 , EventDependencyFilter =
-      ./schemas/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall sha256:10333f512d2e1b95c959bdd25f5828f16ddc66bd771286216ad2d600c0bbd488
+      ./schemas/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall sha256:ca46abde14f4537ea99d711d48ee31362a8baaf87f32cf89efd92e1c49255585
     ? ./schemas/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall
 , FileArtifact =
       ./schemas/io.argoproj.sensor.v1alpha1.FileArtifact.dhall sha256:bab31a470794b22976cd088e3a83dcde19f2462876c7f2d6e6d2d628b4967471
@@ -83,13 +83,13 @@
       ./schemas/io.argoproj.sensor.v1alpha1.GitRemoteConfig.dhall sha256:f2c8bd1a872c511434cfd36eabf155f21c03d1b61b807c91d0f7c81e4a226019
     ? ./schemas/io.argoproj.sensor.v1alpha1.GitRemoteConfig.dhall
 , Sensor =
-      ./schemas/io.argoproj.sensor.v1alpha1.Sensor.dhall sha256:4a5f50f7c9028db639ecb132167902cc3cb350216c427837de122a223ce4a9d3
+      ./schemas/io.argoproj.sensor.v1alpha1.Sensor.dhall sha256:2eeb79e8437a32d01cb54b63964fafb6006a425be4a6034c3e0f2b9ad03eea16
     ? ./schemas/io.argoproj.sensor.v1alpha1.Sensor.dhall
 , SensorList =
-      ./schemas/io.argoproj.sensor.v1alpha1.SensorList.dhall sha256:fc8ad92417d8cb3f2c3372ab90970f9c46cc8647c0b7fd7777828b0b81535807
+      ./schemas/io.argoproj.sensor.v1alpha1.SensorList.dhall sha256:7bf2e2278d39f84bbe4385e2e0f7733d16bd3c991524efd2a494ee208935b792
     ? ./schemas/io.argoproj.sensor.v1alpha1.SensorList.dhall
 , SensorSpec =
-      ./schemas/io.argoproj.sensor.v1alpha1.SensorSpec.dhall sha256:1857a0591499e67c7eb6be8e6881b51080d0ddcdfee71a7d83ef352521c7ac2f
+      ./schemas/io.argoproj.sensor.v1alpha1.SensorSpec.dhall sha256:22a700988955913dec55c03670d958ac9ace0a612ebaaf15de3fc8ee85424aee
     ? ./schemas/io.argoproj.sensor.v1alpha1.SensorSpec.dhall
 , SensorStatus =
       ./schemas/io.argoproj.sensor.v1alpha1.SensorStatus.dhall sha256:b9a0f6973e6a4560cab16c14151dcf162143914eff5b346b51d63dfcd737e18d
@@ -98,7 +98,7 @@
       ./schemas/io.argoproj.sensor.v1alpha1.TimeFilter.dhall sha256:a4514eccdb405dcfec62d1e2054402b5d7b4169029602b1f34123e9db8675d93
     ? ./schemas/io.argoproj.sensor.v1alpha1.TimeFilter.dhall
 , Trigger =
-      ./schemas/io.argoproj.sensor.v1alpha1.Trigger.dhall sha256:73092d52f09244c6903b167812fcd71c9945dd09ca524afa3f91f1bc81c91ef8
+      ./schemas/io.argoproj.sensor.v1alpha1.Trigger.dhall sha256:3c96d01ada4a668224b1d68997a72475cc2c483b16df04cd29998b4e4f191fb1
     ? ./schemas/io.argoproj.sensor.v1alpha1.Trigger.dhall
 , TriggerCondition =
       ./schemas/io.argoproj.sensor.v1alpha1.TriggerCondition.dhall sha256:911e83697e2a50a338ef1d34e7d5a1437e2e171ac4e6143d785aae34ed208284
@@ -116,7 +116,7 @@
       ./schemas/io.argoproj.sensor.v1alpha1.TriggerStateLabels.dhall sha256:8bb6bb7806d8124409e0a94feb1a9f8f0a06f61f46a8c0a6f59b534f58db885e
     ? ./schemas/io.argoproj.sensor.v1alpha1.TriggerStateLabels.dhall
 , TriggerTemplate =
-      ./schemas/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall sha256:fa6ea96bcb8064fca1b37684d68a3f959547b9edd351cbbe64188f535a1b586e
+      ./schemas/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall sha256:7f782ffaf085606a203e76546860a17d1de8713d0ed79ed73ac923540dd68639
     ? ./schemas/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall
 , URLArtifact =
       ./schemas/io.argoproj.sensor.v1alpha1.URLArtifact.dhall sha256:5d592e3ba81fcfc217cfe34bc0dc4b49d015f40bbfffc508a281b231167b4258

--- a/kubernetes/argo-events/schemas/io.argoproj.common.EventProtocol.dhall
+++ b/kubernetes/argo-events/schemas/io.argoproj.common.EventProtocol.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.common.EventProtocol.dhall sha256:64208d24bb507038a09600980ab0f365954978cfe5fa8cecf92f01a7c01448f5
+      ./../types/io.argoproj.common.EventProtocol.dhall sha256:d0232a19cbeb035060087cbf4924b412e02c6677b08e4223d24dccf412dd5ff5
     ? ./../types/io.argoproj.common.EventProtocol.dhall
 , default =
-      ./../defaults/io.argoproj.common.EventProtocol.dhall sha256:595717e9898866ffc565bbba97992241804679d9af1b2ae7240eb92edafb4377
+      ./../defaults/io.argoproj.common.EventProtocol.dhall sha256:65823d7a1d46ecb511dc3e55892be011e726346b6b7a436258d783490b36ba5a
     ? ./../defaults/io.argoproj.common.EventProtocol.dhall
 }

--- a/kubernetes/argo-events/schemas/io.argoproj.gateway.v1alpha1.Gateway.dhall
+++ b/kubernetes/argo-events/schemas/io.argoproj.gateway.v1alpha1.Gateway.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.gateway.v1alpha1.Gateway.dhall sha256:099f71ccd7350834abc4cc7887e10fff3d192cc0598d6e73335606b11691c1d5
+      ./../types/io.argoproj.gateway.v1alpha1.Gateway.dhall sha256:eaef66a79ed76dfd4b84726568eacbf64e00e445b12f31d73960f8865676309a
     ? ./../types/io.argoproj.gateway.v1alpha1.Gateway.dhall
 , default =
-      ./../defaults/io.argoproj.gateway.v1alpha1.Gateway.dhall sha256:8c5173622a53c1c96cbc7d81a25850ca26a7a006443599d3ef7459a257aad754
+      ./../defaults/io.argoproj.gateway.v1alpha1.Gateway.dhall sha256:5bbf5dd600bc192950a95ff043d4b4e58975ffbf3352514a9c095dfae15a5321
     ? ./../defaults/io.argoproj.gateway.v1alpha1.Gateway.dhall
 }

--- a/kubernetes/argo-events/schemas/io.argoproj.gateway.v1alpha1.GatewayList.dhall
+++ b/kubernetes/argo-events/schemas/io.argoproj.gateway.v1alpha1.GatewayList.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.gateway.v1alpha1.GatewayList.dhall sha256:a8257889ce0fb635390b2b2b28d42e125e5e713e0667904f82d8b378ba899734
+      ./../types/io.argoproj.gateway.v1alpha1.GatewayList.dhall sha256:02c6edabdab075c36ac6a83b056aaebb50456017c4015975184444bf4b4bbd57
     ? ./../types/io.argoproj.gateway.v1alpha1.GatewayList.dhall
 , default =
-      ./../defaults/io.argoproj.gateway.v1alpha1.GatewayList.dhall sha256:96a6c5cb95450e19e7c808deac66afa1224795ec16b6b2ca4787a6514f4d0536
+      ./../defaults/io.argoproj.gateway.v1alpha1.GatewayList.dhall sha256:60aafe16c9922a28918284b77bffe37aac4646afd831936ab3233fb5f8d9d640
     ? ./../defaults/io.argoproj.gateway.v1alpha1.GatewayList.dhall
 }

--- a/kubernetes/argo-events/schemas/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall
+++ b/kubernetes/argo-events/schemas/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall sha256:857a3bd3ae86eda94c1dff9c8b803d547548eee35164b7ea757d4acdbf88a0b9
+      ./../types/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall sha256:150ab7e45133bed4d09083f92b7397abc92de63ec4949e6aabc93ab27817b0f1
     ? ./../types/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall
 , default =
-      ./../defaults/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall sha256:128ac3e5d79c499300f775399bc169d907dca8ac0fd2ef5abad81785e903e296
+      ./../defaults/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall sha256:61e874bcd031ed04e2eec8184a6a8130fef3ca0687785a81dd9b92c0dd29c7a2
     ? ./../defaults/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall
 }

--- a/kubernetes/argo-events/schemas/io.argoproj.sensor.v1alpha1.EventDependency.dhall
+++ b/kubernetes/argo-events/schemas/io.argoproj.sensor.v1alpha1.EventDependency.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.sensor.v1alpha1.EventDependency.dhall sha256:2e475774c543fc6ca35b5874178b42b8676651f39af853dd00ced266b4150a2e
+      ./../types/io.argoproj.sensor.v1alpha1.EventDependency.dhall sha256:999968e4fec01dacd5adde195e67ec343538748208cb57d4d0cfa44d097f328e
     ? ./../types/io.argoproj.sensor.v1alpha1.EventDependency.dhall
 , default =
-      ./../defaults/io.argoproj.sensor.v1alpha1.EventDependency.dhall sha256:5bd22a999bc5e22cdbd16b5ae679b12ef15493144a1c1aa1f77712129518da3b
+      ./../defaults/io.argoproj.sensor.v1alpha1.EventDependency.dhall sha256:3a91f3a97ce99eb211e54c7b74eb56f05c0bcd85c9ccdbd6d90dacf0f90484c3
     ? ./../defaults/io.argoproj.sensor.v1alpha1.EventDependency.dhall
 }

--- a/kubernetes/argo-events/schemas/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall
+++ b/kubernetes/argo-events/schemas/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall sha256:9cf11d71d3ba3bb2567725359cc81265335fe484cd130fa212a8ed6619e79799
+      ./../types/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall sha256:c7475ea5bb14bb2091202e58125c71ef61cfb292d7e7c17a8a3966ebc747381c
     ? ./../types/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall
 , default =
-      ./../defaults/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall sha256:d246d77f397c20815b1a74318ff35c9ca14d4a2a42aac00570424886d1bd46eb
+      ./../defaults/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall sha256:38fa3ee91e63c594cd6aa8eafd9159472380b45f70474cfb271ecc06d40b0979
     ? ./../defaults/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall
 }

--- a/kubernetes/argo-events/schemas/io.argoproj.sensor.v1alpha1.Sensor.dhall
+++ b/kubernetes/argo-events/schemas/io.argoproj.sensor.v1alpha1.Sensor.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.sensor.v1alpha1.Sensor.dhall sha256:8c5385fad5951d3806d4efce6c5070ecb86e342a4b5cb4a3bc1a089c7435d4cd
+      ./../types/io.argoproj.sensor.v1alpha1.Sensor.dhall sha256:f661ba5469b568558a8666d06891732a7cae9c155c1dc31d5fca54fe5595120b
     ? ./../types/io.argoproj.sensor.v1alpha1.Sensor.dhall
 , default =
-      ./../defaults/io.argoproj.sensor.v1alpha1.Sensor.dhall sha256:9c9d8e8d1c1615b676e7ded7680cd3b3dbf37bb168b19d74ee4ff6d83cd95ea5
+      ./../defaults/io.argoproj.sensor.v1alpha1.Sensor.dhall sha256:57720130c88127c6cdb70df702be5fd27b6b5b09cab9a29c30e470eac1a62668
     ? ./../defaults/io.argoproj.sensor.v1alpha1.Sensor.dhall
 }

--- a/kubernetes/argo-events/schemas/io.argoproj.sensor.v1alpha1.SensorList.dhall
+++ b/kubernetes/argo-events/schemas/io.argoproj.sensor.v1alpha1.SensorList.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.sensor.v1alpha1.SensorList.dhall sha256:1cf22fe7c75b5a4f92ec8fba3f4956764f2ea57b29e6cbae420d06a63824d132
+      ./../types/io.argoproj.sensor.v1alpha1.SensorList.dhall sha256:070ff1e1657420921f3edd20d5a17ded65f580ad2b4e520c722b6152b830a03d
     ? ./../types/io.argoproj.sensor.v1alpha1.SensorList.dhall
 , default =
-      ./../defaults/io.argoproj.sensor.v1alpha1.SensorList.dhall sha256:58edad8bc62f024a186adb8675c767935cdc6bcdf66356b0e2fd72791ee61d41
+      ./../defaults/io.argoproj.sensor.v1alpha1.SensorList.dhall sha256:e6f1134688b164d76ba1997ddb61773d276fb5dd308313ed4965669fd1e1fc06
     ? ./../defaults/io.argoproj.sensor.v1alpha1.SensorList.dhall
 }

--- a/kubernetes/argo-events/schemas/io.argoproj.sensor.v1alpha1.SensorSpec.dhall
+++ b/kubernetes/argo-events/schemas/io.argoproj.sensor.v1alpha1.SensorSpec.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.sensor.v1alpha1.SensorSpec.dhall sha256:f2653ec82c96e9273ebd754c21d88f733104689f09f24ffbfb38f4f232699608
+      ./../types/io.argoproj.sensor.v1alpha1.SensorSpec.dhall sha256:8b756e4e5c7acc74e859e4a560b88bdb462ecfbf2dc70da687747c00ec466200
     ? ./../types/io.argoproj.sensor.v1alpha1.SensorSpec.dhall
 , default =
-      ./../defaults/io.argoproj.sensor.v1alpha1.SensorSpec.dhall sha256:6fbaa758420f8c09c0aadc40a2556d96c1614aa46e130a4ccfa71df4974281aa
+      ./../defaults/io.argoproj.sensor.v1alpha1.SensorSpec.dhall sha256:e3462106e552d0d338751b4defdb77d8665d453623666d3f1a77e7d984f2adbf
     ? ./../defaults/io.argoproj.sensor.v1alpha1.SensorSpec.dhall
 }

--- a/kubernetes/argo-events/schemas/io.argoproj.sensor.v1alpha1.Trigger.dhall
+++ b/kubernetes/argo-events/schemas/io.argoproj.sensor.v1alpha1.Trigger.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.sensor.v1alpha1.Trigger.dhall sha256:ef1d89439d9348e29c0b93fdb4ede786a6b7e6ebcda4cccbaa581f5051f1ee2e
+      ./../types/io.argoproj.sensor.v1alpha1.Trigger.dhall sha256:b299619204344298bf28313fd49730e1fe2ed4bcff2e969d44ca70e5a03f950d
     ? ./../types/io.argoproj.sensor.v1alpha1.Trigger.dhall
 , default =
-      ./../defaults/io.argoproj.sensor.v1alpha1.Trigger.dhall sha256:f002b3a5e5458a2d5c718b36927cd20f7b24a0526b28385d50a082d6f05f52d3
+      ./../defaults/io.argoproj.sensor.v1alpha1.Trigger.dhall sha256:0fc4f1e2c85a533bcb0ce00418a7d90577729d5fe5dc88d4e7bab95e20f727fd
     ? ./../defaults/io.argoproj.sensor.v1alpha1.Trigger.dhall
 }

--- a/kubernetes/argo-events/schemas/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall
+++ b/kubernetes/argo-events/schemas/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./../types/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall sha256:fa9b003f910b2703e3bc87dcd1ba1a509405895a2cdb1e871c124041feb8e1bf
+      ./../types/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall sha256:27a761b639686171d9f629b914e22ea0cd34e59e5022f1d5c26a9b3a334a3e24
     ? ./../types/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall
 , default =
       ./../defaults/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall sha256:ce6c6234deb3b2a3992280218dd2772bb9a9d14eadeb209b80dac7d2bfa8a602

--- a/kubernetes/argo-events/types.dhall
+++ b/kubernetes/argo-events/types.dhall
@@ -5,7 +5,7 @@
       ./types/io.argoproj.common.EventContext.dhall sha256:5498b0a1675bbc617e96443115ac9911412a092930feb4e958ef995153fc4a1b
     ? ./types/io.argoproj.common.EventContext.dhall
 , EventProtocol =
-      ./types/io.argoproj.common.EventProtocol.dhall sha256:64208d24bb507038a09600980ab0f365954978cfe5fa8cecf92f01a7c01448f5
+      ./types/io.argoproj.common.EventProtocol.dhall sha256:d0232a19cbeb035060087cbf4924b412e02c6677b08e4223d24dccf412dd5ff5
     ? ./types/io.argoproj.common.EventProtocol.dhall
 , Http =
       ./types/io.argoproj.common.Http.dhall sha256:008bbd365377a850574776abce886a072765a967b876e492c1c51afab13f2e19
@@ -29,16 +29,16 @@
       ./types/io.argoproj.common.URI.dhall sha256:eee455b756907ea30fa79e4b09b31f7dfe157c9bda5c980370b36976a147fb85
     ? ./types/io.argoproj.common.URI.dhall
 , Gateway =
-      ./types/io.argoproj.gateway.v1alpha1.Gateway.dhall sha256:099f71ccd7350834abc4cc7887e10fff3d192cc0598d6e73335606b11691c1d5
+      ./types/io.argoproj.gateway.v1alpha1.Gateway.dhall sha256:eaef66a79ed76dfd4b84726568eacbf64e00e445b12f31d73960f8865676309a
     ? ./types/io.argoproj.gateway.v1alpha1.Gateway.dhall
 , GatewayList =
-      ./types/io.argoproj.gateway.v1alpha1.GatewayList.dhall sha256:a8257889ce0fb635390b2b2b28d42e125e5e713e0667904f82d8b378ba899734
+      ./types/io.argoproj.gateway.v1alpha1.GatewayList.dhall sha256:02c6edabdab075c36ac6a83b056aaebb50456017c4015975184444bf4b4bbd57
     ? ./types/io.argoproj.gateway.v1alpha1.GatewayList.dhall
 , GatewayNotificationWatcher =
       ./types/io.argoproj.gateway.v1alpha1.GatewayNotificationWatcher.dhall sha256:0a8593e805770f032241ca46c0d45d76e5d417170b9ecb8182120a1b6104c009
     ? ./types/io.argoproj.gateway.v1alpha1.GatewayNotificationWatcher.dhall
 , GatewaySpec =
-      ./types/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall sha256:857a3bd3ae86eda94c1dff9c8b803d547548eee35164b7ea757d4acdbf88a0b9
+      ./types/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall sha256:150ab7e45133bed4d09083f92b7397abc92de63ec4949e6aabc93ab27817b0f1
     ? ./types/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall
 , GatewayStatus =
       ./types/io.argoproj.gateway.v1alpha1.GatewayStatus.dhall sha256:f9c4c6302fdf182c86abc417040942701b3dd7d526105914793262d229398cf5
@@ -65,10 +65,10 @@
       ./types/io.argoproj.sensor.v1alpha1.DependencyGroup.dhall sha256:425a051e95a326d1c520c3453f5610f346a24199fc9e80139697a34c9c1347ae
     ? ./types/io.argoproj.sensor.v1alpha1.DependencyGroup.dhall
 , EventDependency =
-      ./types/io.argoproj.sensor.v1alpha1.EventDependency.dhall sha256:2e475774c543fc6ca35b5874178b42b8676651f39af853dd00ced266b4150a2e
+      ./types/io.argoproj.sensor.v1alpha1.EventDependency.dhall sha256:999968e4fec01dacd5adde195e67ec343538748208cb57d4d0cfa44d097f328e
     ? ./types/io.argoproj.sensor.v1alpha1.EventDependency.dhall
 , EventDependencyFilter =
-      ./types/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall sha256:9cf11d71d3ba3bb2567725359cc81265335fe484cd130fa212a8ed6619e79799
+      ./types/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall sha256:c7475ea5bb14bb2091202e58125c71ef61cfb292d7e7c17a8a3966ebc747381c
     ? ./types/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall
 , FileArtifact =
       ./types/io.argoproj.sensor.v1alpha1.FileArtifact.dhall sha256:32e7fda1f3ca2693794ac65e8aebb7e2bd2df5983f00224bd93a94e1cbdd7420
@@ -83,13 +83,13 @@
       ./types/io.argoproj.sensor.v1alpha1.GitRemoteConfig.dhall sha256:e1639cc8552108b90d660a4d917083b2c296cff3e61d805f885784b3a00299cc
     ? ./types/io.argoproj.sensor.v1alpha1.GitRemoteConfig.dhall
 , Sensor =
-      ./types/io.argoproj.sensor.v1alpha1.Sensor.dhall sha256:8c5385fad5951d3806d4efce6c5070ecb86e342a4b5cb4a3bc1a089c7435d4cd
+      ./types/io.argoproj.sensor.v1alpha1.Sensor.dhall sha256:f661ba5469b568558a8666d06891732a7cae9c155c1dc31d5fca54fe5595120b
     ? ./types/io.argoproj.sensor.v1alpha1.Sensor.dhall
 , SensorList =
-      ./types/io.argoproj.sensor.v1alpha1.SensorList.dhall sha256:1cf22fe7c75b5a4f92ec8fba3f4956764f2ea57b29e6cbae420d06a63824d132
+      ./types/io.argoproj.sensor.v1alpha1.SensorList.dhall sha256:070ff1e1657420921f3edd20d5a17ded65f580ad2b4e520c722b6152b830a03d
     ? ./types/io.argoproj.sensor.v1alpha1.SensorList.dhall
 , SensorSpec =
-      ./types/io.argoproj.sensor.v1alpha1.SensorSpec.dhall sha256:f2653ec82c96e9273ebd754c21d88f733104689f09f24ffbfb38f4f232699608
+      ./types/io.argoproj.sensor.v1alpha1.SensorSpec.dhall sha256:8b756e4e5c7acc74e859e4a560b88bdb462ecfbf2dc70da687747c00ec466200
     ? ./types/io.argoproj.sensor.v1alpha1.SensorSpec.dhall
 , SensorStatus =
       ./types/io.argoproj.sensor.v1alpha1.SensorStatus.dhall sha256:a7a5b93d43239663c5da523754c1a34d8e58172a934370427253c2a96dfc0acc
@@ -98,7 +98,7 @@
       ./types/io.argoproj.sensor.v1alpha1.TimeFilter.dhall sha256:08b2e66593f50b2f8d059b80a2fe8b010c866918df8e8f61f5c65eb42061459b
     ? ./types/io.argoproj.sensor.v1alpha1.TimeFilter.dhall
 , Trigger =
-      ./types/io.argoproj.sensor.v1alpha1.Trigger.dhall sha256:ef1d89439d9348e29c0b93fdb4ede786a6b7e6ebcda4cccbaa581f5051f1ee2e
+      ./types/io.argoproj.sensor.v1alpha1.Trigger.dhall sha256:b299619204344298bf28313fd49730e1fe2ed4bcff2e969d44ca70e5a03f950d
     ? ./types/io.argoproj.sensor.v1alpha1.Trigger.dhall
 , TriggerCondition =
       ./types/io.argoproj.sensor.v1alpha1.TriggerCondition.dhall sha256:4e394f7cb18c49fb976986624236a3134cbb5c073cf57c880f85b30f41339ee2
@@ -116,7 +116,7 @@
       ./types/io.argoproj.sensor.v1alpha1.TriggerStateLabels.dhall sha256:44636ce138963163856f624867e85656559eee3ef8a194e6c6fbf4386022c56f
     ? ./types/io.argoproj.sensor.v1alpha1.TriggerStateLabels.dhall
 , TriggerTemplate =
-      ./types/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall sha256:fa9b003f910b2703e3bc87dcd1ba1a509405895a2cdb1e871c124041feb8e1bf
+      ./types/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall sha256:27a761b639686171d9f629b914e22ea0cd34e59e5022f1d5c26a9b3a334a3e24
     ? ./types/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall
 , URLArtifact =
       ./types/io.argoproj.sensor.v1alpha1.URLArtifact.dhall sha256:26efbbfd783deadaf56afff4a372a81588dda6d82aa9d0b88f23224853a72f42

--- a/kubernetes/argo-events/types/io.argoproj.common.EventProtocol.dhall
+++ b/kubernetes/argo-events/types/io.argoproj.common.EventProtocol.dhall
@@ -1,8 +1,12 @@
 { http :
-      ./io.argoproj.common.Http.dhall sha256:008bbd365377a850574776abce886a072765a967b876e492c1c51afab13f2e19
-    ? ./io.argoproj.common.Http.dhall
+    Optional
+      (   ./io.argoproj.common.Http.dhall sha256:008bbd365377a850574776abce886a072765a967b876e492c1c51afab13f2e19
+        ? ./io.argoproj.common.Http.dhall
+      )
 , nats :
-      ./io.argoproj.common.Nats.dhall sha256:ffacddff3a7a785e889ac7c8f70baaeb41172d747f508ccd648239628aa65e3a
-    ? ./io.argoproj.common.Nats.dhall
+    Optional
+      (   ./io.argoproj.common.Nats.dhall sha256:ffacddff3a7a785e889ac7c8f70baaeb41172d747f508ccd648239628aa65e3a
+        ? ./io.argoproj.common.Nats.dhall
+      )
 , type : Text
 }

--- a/kubernetes/argo-events/types/io.argoproj.gateway.v1alpha1.Gateway.dhall
+++ b/kubernetes/argo-events/types/io.argoproj.gateway.v1alpha1.Gateway.dhall
@@ -4,9 +4,11 @@
       https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall sha256:f0672df8d25dd0e384d486b81d8f551c55d5d6a5868374a5bd35ee0a525f8cee
     ? https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec :
-      ./io.argoproj.gateway.v1alpha1.GatewaySpec.dhall sha256:857a3bd3ae86eda94c1dff9c8b803d547548eee35164b7ea757d4acdbf88a0b9
+      ./io.argoproj.gateway.v1alpha1.GatewaySpec.dhall sha256:150ab7e45133bed4d09083f92b7397abc92de63ec4949e6aabc93ab27817b0f1
     ? ./io.argoproj.gateway.v1alpha1.GatewaySpec.dhall
 , status :
-      ./io.argoproj.gateway.v1alpha1.GatewayStatus.dhall sha256:f9c4c6302fdf182c86abc417040942701b3dd7d526105914793262d229398cf5
-    ? ./io.argoproj.gateway.v1alpha1.GatewayStatus.dhall
+    Optional
+      (   ./io.argoproj.gateway.v1alpha1.GatewayStatus.dhall sha256:f9c4c6302fdf182c86abc417040942701b3dd7d526105914793262d229398cf5
+        ? ./io.argoproj.gateway.v1alpha1.GatewayStatus.dhall
+      )
 }

--- a/kubernetes/argo-events/types/io.argoproj.gateway.v1alpha1.GatewayList.dhall
+++ b/kubernetes/argo-events/types/io.argoproj.gateway.v1alpha1.GatewayList.dhall
@@ -1,7 +1,7 @@
 { apiVersion : Text
 , items :
     List
-      (   ./io.argoproj.gateway.v1alpha1.Gateway.dhall sha256:099f71ccd7350834abc4cc7887e10fff3d192cc0598d6e73335606b11691c1d5
+      (   ./io.argoproj.gateway.v1alpha1.Gateway.dhall sha256:eaef66a79ed76dfd4b84726568eacbf64e00e445b12f31d73960f8865676309a
         ? ./io.argoproj.gateway.v1alpha1.Gateway.dhall
       )
 , kind : Text

--- a/kubernetes/argo-events/types/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall
+++ b/kubernetes/argo-events/types/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall
@@ -1,5 +1,5 @@
 { eventProtocol :
-      ./io.argoproj.common.EventProtocol.dhall sha256:64208d24bb507038a09600980ab0f365954978cfe5fa8cecf92f01a7c01448f5
+      ./io.argoproj.common.EventProtocol.dhall sha256:d0232a19cbeb035060087cbf4924b412e02c6677b08e4223d24dccf412dd5ff5
     ? ./io.argoproj.common.EventProtocol.dhall
 , processorPort : Text
 , template :

--- a/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.EventDependency.dhall
+++ b/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.EventDependency.dhall
@@ -2,7 +2,7 @@
 , connected : Optional Bool
 , filters :
     Optional
-      (   ./io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall sha256:9cf11d71d3ba3bb2567725359cc81265335fe484cd130fa212a8ed6619e79799
+      (   ./io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall sha256:c7475ea5bb14bb2091202e58125c71ef61cfb292d7e7c17a8a3966ebc747381c
         ? ./io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall
       )
 }

--- a/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall
+++ b/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall
@@ -5,8 +5,10 @@
       )
 , name : Text
 , time :
-      ./io.argoproj.sensor.v1alpha1.TimeFilter.dhall sha256:08b2e66593f50b2f8d059b80a2fe8b010c866918df8e8f61f5c65eb42061459b
-    ? ./io.argoproj.sensor.v1alpha1.TimeFilter.dhall
+    Optional
+      (   ./io.argoproj.sensor.v1alpha1.TimeFilter.dhall sha256:08b2e66593f50b2f8d059b80a2fe8b010c866918df8e8f61f5c65eb42061459b
+        ? ./io.argoproj.sensor.v1alpha1.TimeFilter.dhall
+      )
 , context :
     Optional
       (   ./io.argoproj.common.EventContext.dhall sha256:5498b0a1675bbc617e96443115ac9911412a092930feb4e958ef995153fc4a1b

--- a/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.Sensor.dhall
+++ b/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.Sensor.dhall
@@ -4,9 +4,11 @@
       https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall sha256:f0672df8d25dd0e384d486b81d8f551c55d5d6a5868374a5bd35ee0a525f8cee
     ? https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec :
-      ./io.argoproj.sensor.v1alpha1.SensorSpec.dhall sha256:f2653ec82c96e9273ebd754c21d88f733104689f09f24ffbfb38f4f232699608
+      ./io.argoproj.sensor.v1alpha1.SensorSpec.dhall sha256:8b756e4e5c7acc74e859e4a560b88bdb462ecfbf2dc70da687747c00ec466200
     ? ./io.argoproj.sensor.v1alpha1.SensorSpec.dhall
 , status :
-      ./io.argoproj.sensor.v1alpha1.SensorStatus.dhall sha256:a7a5b93d43239663c5da523754c1a34d8e58172a934370427253c2a96dfc0acc
-    ? ./io.argoproj.sensor.v1alpha1.SensorStatus.dhall
+    Optional
+      (   ./io.argoproj.sensor.v1alpha1.SensorStatus.dhall sha256:a7a5b93d43239663c5da523754c1a34d8e58172a934370427253c2a96dfc0acc
+        ? ./io.argoproj.sensor.v1alpha1.SensorStatus.dhall
+      )
 }

--- a/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.SensorList.dhall
+++ b/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.SensorList.dhall
@@ -1,7 +1,7 @@
 { apiVersion : Text
 , items :
     List
-      (   ./io.argoproj.sensor.v1alpha1.Sensor.dhall sha256:8c5385fad5951d3806d4efce6c5070ecb86e342a4b5cb4a3bc1a089c7435d4cd
+      (   ./io.argoproj.sensor.v1alpha1.Sensor.dhall sha256:f661ba5469b568558a8666d06891732a7cae9c155c1dc31d5fca54fe5595120b
         ? ./io.argoproj.sensor.v1alpha1.Sensor.dhall
       )
 , kind : Text

--- a/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.SensorSpec.dhall
+++ b/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.SensorSpec.dhall
@@ -1,6 +1,6 @@
 { dependencies :
     List
-      (   ./io.argoproj.sensor.v1alpha1.EventDependency.dhall sha256:2e475774c543fc6ca35b5874178b42b8676651f39af853dd00ced266b4150a2e
+      (   ./io.argoproj.sensor.v1alpha1.EventDependency.dhall sha256:999968e4fec01dacd5adde195e67ec343538748208cb57d4d0cfa44d097f328e
         ? ./io.argoproj.sensor.v1alpha1.EventDependency.dhall
       )
 , dependencyGroups :
@@ -9,14 +9,14 @@
         ? ./io.argoproj.sensor.v1alpha1.DependencyGroup.dhall
       )
 , eventProtocol :
-      ./io.argoproj.common.EventProtocol.dhall sha256:64208d24bb507038a09600980ab0f365954978cfe5fa8cecf92f01a7c01448f5
+      ./io.argoproj.common.EventProtocol.dhall sha256:d0232a19cbeb035060087cbf4924b412e02c6677b08e4223d24dccf412dd5ff5
     ? ./io.argoproj.common.EventProtocol.dhall
 , template :
       https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/types/io.k8s.api.core.v1.PodTemplateSpec.dhall sha256:4d56cb0fb1f61ae6aee0a0dd0da929c7caa3275a0b2cb83aedfe7d67b3797aca
     ? https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/types/io.k8s.api.core.v1.PodTemplateSpec.dhall
 , triggers :
     List
-      (   ./io.argoproj.sensor.v1alpha1.Trigger.dhall sha256:ef1d89439d9348e29c0b93fdb4ede786a6b7e6ebcda4cccbaa581f5051f1ee2e
+      (   ./io.argoproj.sensor.v1alpha1.Trigger.dhall sha256:b299619204344298bf28313fd49730e1fe2ed4bcff2e969d44ca70e5a03f950d
         ? ./io.argoproj.sensor.v1alpha1.Trigger.dhall
       )
 , circuit : Optional Text

--- a/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.Trigger.dhall
+++ b/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.Trigger.dhall
@@ -1,13 +1,15 @@
 { policy :
-      ./io.argoproj.sensor.v1alpha1.TriggerPolicy.dhall sha256:4368ac346df3a447efddce45d73c3ce2a61b8255757adf6df5d5525a2ee3918b
-    ? ./io.argoproj.sensor.v1alpha1.TriggerPolicy.dhall
+    Optional
+      (   ./io.argoproj.sensor.v1alpha1.TriggerPolicy.dhall sha256:4368ac346df3a447efddce45d73c3ce2a61b8255757adf6df5d5525a2ee3918b
+        ? ./io.argoproj.sensor.v1alpha1.TriggerPolicy.dhall
+      )
 , resourceParameters :
     List
       (   ./io.argoproj.sensor.v1alpha1.TriggerParameter.dhall sha256:8a4ba38bbb1db06cd3aed94150e9c2733d7f3aed016d97d060491fa2f3af6b45
         ? ./io.argoproj.sensor.v1alpha1.TriggerParameter.dhall
       )
 , template :
-      ./io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall sha256:fa9b003f910b2703e3bc87dcd1ba1a509405895a2cdb1e871c124041feb8e1bf
+      ./io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall sha256:27a761b639686171d9f629b914e22ea0cd34e59e5022f1d5c26a9b3a334a3e24
     ? ./io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall
 , templateParameters :
     List

--- a/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall
+++ b/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall
@@ -7,4 +7,7 @@
       (   ./io.argoproj.sensor.v1alpha1.TriggerCondition.dhall sha256:4e394f7cb18c49fb976986624236a3134cbb5c073cf57c880f85b30f41339ee2
         ? ./io.argoproj.sensor.v1alpha1.TriggerCondition.dhall
       )
+, group : Text
+, version : Text
+, resource : Text
 }

--- a/kubernetes/argo-events/typesUnion.dhall
+++ b/kubernetes/argo-events/typesUnion.dhall
@@ -5,7 +5,7 @@
       ./types/io.argoproj.common.EventContext.dhall sha256:5498b0a1675bbc617e96443115ac9911412a092930feb4e958ef995153fc4a1b
     ? ./types/io.argoproj.common.EventContext.dhall
 | EventProtocol :
-      ./types/io.argoproj.common.EventProtocol.dhall sha256:64208d24bb507038a09600980ab0f365954978cfe5fa8cecf92f01a7c01448f5
+      ./types/io.argoproj.common.EventProtocol.dhall sha256:d0232a19cbeb035060087cbf4924b412e02c6677b08e4223d24dccf412dd5ff5
     ? ./types/io.argoproj.common.EventProtocol.dhall
 | Http :
       ./types/io.argoproj.common.Http.dhall sha256:008bbd365377a850574776abce886a072765a967b876e492c1c51afab13f2e19
@@ -29,16 +29,16 @@
       ./types/io.argoproj.common.URI.dhall sha256:eee455b756907ea30fa79e4b09b31f7dfe157c9bda5c980370b36976a147fb85
     ? ./types/io.argoproj.common.URI.dhall
 | Gateway :
-      ./types/io.argoproj.gateway.v1alpha1.Gateway.dhall sha256:099f71ccd7350834abc4cc7887e10fff3d192cc0598d6e73335606b11691c1d5
+      ./types/io.argoproj.gateway.v1alpha1.Gateway.dhall sha256:eaef66a79ed76dfd4b84726568eacbf64e00e445b12f31d73960f8865676309a
     ? ./types/io.argoproj.gateway.v1alpha1.Gateway.dhall
 | GatewayList :
-      ./types/io.argoproj.gateway.v1alpha1.GatewayList.dhall sha256:a8257889ce0fb635390b2b2b28d42e125e5e713e0667904f82d8b378ba899734
+      ./types/io.argoproj.gateway.v1alpha1.GatewayList.dhall sha256:02c6edabdab075c36ac6a83b056aaebb50456017c4015975184444bf4b4bbd57
     ? ./types/io.argoproj.gateway.v1alpha1.GatewayList.dhall
 | GatewayNotificationWatcher :
       ./types/io.argoproj.gateway.v1alpha1.GatewayNotificationWatcher.dhall sha256:0a8593e805770f032241ca46c0d45d76e5d417170b9ecb8182120a1b6104c009
     ? ./types/io.argoproj.gateway.v1alpha1.GatewayNotificationWatcher.dhall
 | GatewaySpec :
-      ./types/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall sha256:857a3bd3ae86eda94c1dff9c8b803d547548eee35164b7ea757d4acdbf88a0b9
+      ./types/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall sha256:150ab7e45133bed4d09083f92b7397abc92de63ec4949e6aabc93ab27817b0f1
     ? ./types/io.argoproj.gateway.v1alpha1.GatewaySpec.dhall
 | GatewayStatus :
       ./types/io.argoproj.gateway.v1alpha1.GatewayStatus.dhall sha256:f9c4c6302fdf182c86abc417040942701b3dd7d526105914793262d229398cf5
@@ -65,10 +65,10 @@
       ./types/io.argoproj.sensor.v1alpha1.DependencyGroup.dhall sha256:425a051e95a326d1c520c3453f5610f346a24199fc9e80139697a34c9c1347ae
     ? ./types/io.argoproj.sensor.v1alpha1.DependencyGroup.dhall
 | EventDependency :
-      ./types/io.argoproj.sensor.v1alpha1.EventDependency.dhall sha256:2e475774c543fc6ca35b5874178b42b8676651f39af853dd00ced266b4150a2e
+      ./types/io.argoproj.sensor.v1alpha1.EventDependency.dhall sha256:999968e4fec01dacd5adde195e67ec343538748208cb57d4d0cfa44d097f328e
     ? ./types/io.argoproj.sensor.v1alpha1.EventDependency.dhall
 | EventDependencyFilter :
-      ./types/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall sha256:9cf11d71d3ba3bb2567725359cc81265335fe484cd130fa212a8ed6619e79799
+      ./types/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall sha256:c7475ea5bb14bb2091202e58125c71ef61cfb292d7e7c17a8a3966ebc747381c
     ? ./types/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall
 | FileArtifact :
       ./types/io.argoproj.sensor.v1alpha1.FileArtifact.dhall sha256:32e7fda1f3ca2693794ac65e8aebb7e2bd2df5983f00224bd93a94e1cbdd7420
@@ -83,13 +83,13 @@
       ./types/io.argoproj.sensor.v1alpha1.GitRemoteConfig.dhall sha256:e1639cc8552108b90d660a4d917083b2c296cff3e61d805f885784b3a00299cc
     ? ./types/io.argoproj.sensor.v1alpha1.GitRemoteConfig.dhall
 | Sensor :
-      ./types/io.argoproj.sensor.v1alpha1.Sensor.dhall sha256:8c5385fad5951d3806d4efce6c5070ecb86e342a4b5cb4a3bc1a089c7435d4cd
+      ./types/io.argoproj.sensor.v1alpha1.Sensor.dhall sha256:f661ba5469b568558a8666d06891732a7cae9c155c1dc31d5fca54fe5595120b
     ? ./types/io.argoproj.sensor.v1alpha1.Sensor.dhall
 | SensorList :
-      ./types/io.argoproj.sensor.v1alpha1.SensorList.dhall sha256:1cf22fe7c75b5a4f92ec8fba3f4956764f2ea57b29e6cbae420d06a63824d132
+      ./types/io.argoproj.sensor.v1alpha1.SensorList.dhall sha256:070ff1e1657420921f3edd20d5a17ded65f580ad2b4e520c722b6152b830a03d
     ? ./types/io.argoproj.sensor.v1alpha1.SensorList.dhall
 | SensorSpec :
-      ./types/io.argoproj.sensor.v1alpha1.SensorSpec.dhall sha256:f2653ec82c96e9273ebd754c21d88f733104689f09f24ffbfb38f4f232699608
+      ./types/io.argoproj.sensor.v1alpha1.SensorSpec.dhall sha256:8b756e4e5c7acc74e859e4a560b88bdb462ecfbf2dc70da687747c00ec466200
     ? ./types/io.argoproj.sensor.v1alpha1.SensorSpec.dhall
 | SensorStatus :
       ./types/io.argoproj.sensor.v1alpha1.SensorStatus.dhall sha256:a7a5b93d43239663c5da523754c1a34d8e58172a934370427253c2a96dfc0acc
@@ -98,7 +98,7 @@
       ./types/io.argoproj.sensor.v1alpha1.TimeFilter.dhall sha256:08b2e66593f50b2f8d059b80a2fe8b010c866918df8e8f61f5c65eb42061459b
     ? ./types/io.argoproj.sensor.v1alpha1.TimeFilter.dhall
 | Trigger :
-      ./types/io.argoproj.sensor.v1alpha1.Trigger.dhall sha256:ef1d89439d9348e29c0b93fdb4ede786a6b7e6ebcda4cccbaa581f5051f1ee2e
+      ./types/io.argoproj.sensor.v1alpha1.Trigger.dhall sha256:b299619204344298bf28313fd49730e1fe2ed4bcff2e969d44ca70e5a03f950d
     ? ./types/io.argoproj.sensor.v1alpha1.Trigger.dhall
 | TriggerCondition :
       ./types/io.argoproj.sensor.v1alpha1.TriggerCondition.dhall sha256:4e394f7cb18c49fb976986624236a3134cbb5c073cf57c880f85b30f41339ee2
@@ -116,7 +116,7 @@
       ./types/io.argoproj.sensor.v1alpha1.TriggerStateLabels.dhall sha256:44636ce138963163856f624867e85656559eee3ef8a194e6c6fbf4386022c56f
     ? ./types/io.argoproj.sensor.v1alpha1.TriggerStateLabels.dhall
 | TriggerTemplate :
-      ./types/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall sha256:fa9b003f910b2703e3bc87dcd1ba1a509405895a2cdb1e871c124041feb8e1bf
+      ./types/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall sha256:27a761b639686171d9f629b914e22ea0cd34e59e5022f1d5c26a9b3a334a3e24
     ? ./types/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall
 | URLArtifact :
       ./types/io.argoproj.sensor.v1alpha1.URLArtifact.dhall sha256:26efbbfd783deadaf56afff4a372a81588dda6d82aa9d0b88f23224853a72f42

--- a/kubernetes/argo/package.dhall
+++ b/kubernetes/argo/package.dhall
@@ -1,0 +1,13 @@
+{ defaults =
+      ./defaults.dhall sha256:2319d102500bd719675f8151b4e84b12e488651d8c07fd9b888ab3a800c4f41d
+    ? ./defaults.dhall
+, types =
+      ./types.dhall sha256:ab35786728384eacc1df2a359135ccfc6c141076b664df4a11c771bff39ec15f
+    ? ./types.dhall
+, typesUnion =
+      ./typesUnion.dhall sha256:33e9a9d619f6b202ac3cfc6f9a9174987de9272c8e25f1f313c6441612da3611
+    ? ./typesUnion.dhall
+, schemas =
+      ./schemas.dhall sha256:0b2f1fd43591a5f4df3156179f601fbea9adc86c740becf5629570bf82a8874e
+    ? ./schemas.dhall
+}

--- a/kubernetes/package.dhall
+++ b/kubernetes/package.dhall
@@ -11,11 +11,11 @@
       ./argocd/package.dhall sha256:da3664e8a089162f27db3d2d552f08e11b923d8546853f20e13f5b9a6d7b26c6
     ? ./argocd/package.dhall
 , argo =
-      ./argo/schemas.dhall sha256:0b2f1fd43591a5f4df3156179f601fbea9adc86c740becf5629570bf82a8874e
-    ? ./argo/schemas.dhall
+      ./argo/package.dhall sha256:72c8a8f37f102ba5bff6bf68885d2c8f53817dfa4215b702bb9c544582048fa6
+    ? ./argo/package.dhall
 , argo-events =
-      ./argo-events/schemas.dhall sha256:fcf8f0804d2ab54011304da6536d663885f1833c41938bf91f0d1ad49117061b
-    ? ./argo-events/schemas.dhall
+      ./argo-events/package.dhall sha256:06fdc660a4abfc141641cfc58855ad52192b9f93d4d8edbaae2f9aba77d1efc7
+    ? ./argo-events/package.dhall
 , ambassador =
       ./ambassador/package.dhall sha256:7c482aa11b7c7d4679e0a8914b89f4c4e07c5b6b70ce961a87082f63f3833c75
     ? ./ambassador/package.dhall

--- a/package.dhall
+++ b/package.dhall
@@ -1,5 +1,5 @@
 { kubernetes =
-      ./kubernetes/package.dhall sha256:cec4c4fb5c4ff592ab4a8be403649e83d9fb69befe02cd946ff0416682f73b66
+      ./kubernetes/package.dhall sha256:9508b0b27dfad81c5c3e0d1b91278d36bd1f08ccba847813285bf3a8adbf91cc
     ? ./kubernetes/package.dhall
 , Prelude =
       https://prelude.dhall-lang.org/v11.1.0/package.dhall sha256:99462c205117931c0919f155a6046aec140c70fb8876d208c7c77027ab19c2fa

--- a/src/kubernetes/argo-events/defaults/io.argoproj.common.EventProtocol.dhall
+++ b/src/kubernetes/argo-events/defaults/io.argoproj.common.EventProtocol.dhall
@@ -1,3 +1,3 @@
-{ http = ./io.argoproj.common.Http.dhall
-, nats = ./io.argoproj.common.Nats.dhall
+{ http = None ../types/io.argoproj.common.Http.dhall
+, nats = None ../types/io.argoproj.common.Nats.dhall
 }

--- a/src/kubernetes/argo-events/defaults/io.argoproj.gateway.v1alpha1.Gateway.dhall
+++ b/src/kubernetes/argo-events/defaults/io.argoproj.gateway.v1alpha1.Gateway.dhall
@@ -1,3 +1,5 @@
 { spec = ./io.argoproj.gateway.v1alpha1.GatewaySpec.dhall
-, status = ./io.argoproj.gateway.v1alpha1.GatewayStatus.dhall
+, status = None ../types/io.argoproj.gateway.v1alpha1.GatewayStatus.dhall
+, apiVersion = "argoproj.io/v1alpha1"
+, kind = "Gateway"
 }

--- a/src/kubernetes/argo-events/defaults/io.argoproj.gateway.v1alpha1.GatewayList.dhall
+++ b/src/kubernetes/argo-events/defaults/io.argoproj.gateway.v1alpha1.GatewayList.dhall
@@ -1,4 +1,4 @@
-{ items = [] : List ./../types/io.argoproj.gateway.v1alpha1.Gateway.dhall 
+{ items = [] : List ./../types/io.argoproj.gateway.v1alpha1.Gateway.dhall
 , apiVersion = "argoproj.io/v1alpha1"
 , kind = "GatewayList"
 }

--- a/src/kubernetes/argo-events/defaults/io.argoproj.gateway.v1alpha1.GatewayList.dhall
+++ b/src/kubernetes/argo-events/defaults/io.argoproj.gateway.v1alpha1.GatewayList.dhall
@@ -1,1 +1,4 @@
-{ items = [] : List ./../types/io.argoproj.gateway.v1alpha1.Gateway.dhall }
+{ items = [] : List ./../types/io.argoproj.gateway.v1alpha1.Gateway.dhall 
+, apiVersion = "argoproj.io/v1alpha1"
+, kind = "GatewayList"
+}

--- a/src/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall
+++ b/src/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall
@@ -1,4 +1,4 @@
 { data = [] : List ./../types/io.argoproj.sensor.v1alpha1.DataFilter.dhall
-, time = ./io.argoproj.sensor.v1alpha1.TimeFilter.dhall
+, time = None ../types/io.argoproj.sensor.v1alpha1.TimeFilter.dhall
 , context = None ./../types/io.argoproj.common.EventContext.dhall
 }

--- a/src/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.Sensor.dhall
+++ b/src/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.Sensor.dhall
@@ -1,3 +1,5 @@
 { spec = ./io.argoproj.sensor.v1alpha1.SensorSpec.dhall
-, status = ./io.argoproj.sensor.v1alpha1.SensorStatus.dhall
+, status = None ../types/io.argoproj.sensor.v1alpha1.SensorStatus.dhall
+, apiVersion = "argoproj.io/v1alpha1"
+, kind = "Sensor"
 }

--- a/src/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.SensorList.dhall
+++ b/src/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.SensorList.dhall
@@ -1,1 +1,4 @@
-{ items = [] : List ./../types/io.argoproj.sensor.v1alpha1.Sensor.dhall }
+{ items = [] : List ./../types/io.argoproj.sensor.v1alpha1.Sensor.dhall 
+, apiVersion = "argoproj.io/v1alpha1"
+, kind = "SensorList"
+}

--- a/src/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.SensorList.dhall
+++ b/src/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.SensorList.dhall
@@ -1,4 +1,4 @@
-{ items = [] : List ./../types/io.argoproj.sensor.v1alpha1.Sensor.dhall 
+{ items = [] : List ./../types/io.argoproj.sensor.v1alpha1.Sensor.dhall
 , apiVersion = "argoproj.io/v1alpha1"
 , kind = "SensorList"
 }

--- a/src/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.Trigger.dhall
+++ b/src/kubernetes/argo-events/defaults/io.argoproj.sensor.v1alpha1.Trigger.dhall
@@ -1,4 +1,4 @@
-{ policy = ./io.argoproj.sensor.v1alpha1.TriggerPolicy.dhall
+{ policy = None ../types/io.argoproj.sensor.v1alpha1.TriggerPolicy.dhall
 , resourceParameters =
     [] : List ./../types/io.argoproj.sensor.v1alpha1.TriggerParameter.dhall
 , template = ./io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall

--- a/src/kubernetes/argo-events/package.dhall
+++ b/src/kubernetes/argo-events/package.dhall
@@ -1,9 +1,5 @@
-{ defaults =
-    ./defaults.dhall
-, types =
-    ./types.dhall
-, typesUnion =
-    ./typesUnion.dhall
-, schemas =
-    ./schemas.dhall 
+{ defaults = ./defaults.dhall
+, types = ./types.dhall
+, typesUnion = ./typesUnion.dhall
+, schemas = ./schemas.dhall
 }

--- a/src/kubernetes/argo-events/package.dhall
+++ b/src/kubernetes/argo-events/package.dhall
@@ -1,0 +1,9 @@
+{ defaults =
+    ./defaults.dhall
+, types =
+    ./types.dhall
+, typesUnion =
+    ./typesUnion.dhall
+, schemas =
+    ./schemas.dhall 
+}

--- a/src/kubernetes/argo-events/types/io.argoproj.common.EventProtocol.dhall
+++ b/src/kubernetes/argo-events/types/io.argoproj.common.EventProtocol.dhall
@@ -1,4 +1,4 @@
-{ http : ./io.argoproj.common.Http.dhall
-, nats : ./io.argoproj.common.Nats.dhall
+{ http : Optional ./io.argoproj.common.Http.dhall
+, nats : Optional ./io.argoproj.common.Nats.dhall
 , type : Text
 }

--- a/src/kubernetes/argo-events/types/io.argoproj.gateway.v1alpha1.Gateway.dhall
+++ b/src/kubernetes/argo-events/types/io.argoproj.gateway.v1alpha1.Gateway.dhall
@@ -3,5 +3,5 @@
 , metadata :
     https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : ./io.argoproj.gateway.v1alpha1.GatewaySpec.dhall
-, status : ./io.argoproj.gateway.v1alpha1.GatewayStatus.dhall
+, status : Optional ./io.argoproj.gateway.v1alpha1.GatewayStatus.dhall
 }

--- a/src/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall
+++ b/src/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.EventDependencyFilter.dhall
@@ -1,5 +1,5 @@
 { data : List ./io.argoproj.sensor.v1alpha1.DataFilter.dhall
 , name : Text
-, time : ./io.argoproj.sensor.v1alpha1.TimeFilter.dhall
+, time : Optional ./io.argoproj.sensor.v1alpha1.TimeFilter.dhall
 , context : Optional ./io.argoproj.common.EventContext.dhall
 }

--- a/src/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.Sensor.dhall
+++ b/src/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.Sensor.dhall
@@ -3,5 +3,5 @@
 , metadata :
     https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec : ./io.argoproj.sensor.v1alpha1.SensorSpec.dhall
-, status : ./io.argoproj.sensor.v1alpha1.SensorStatus.dhall
+, status : Optional ./io.argoproj.sensor.v1alpha1.SensorStatus.dhall
 }

--- a/src/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.Trigger.dhall
+++ b/src/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.Trigger.dhall
@@ -1,4 +1,4 @@
-{ policy : ./io.argoproj.sensor.v1alpha1.TriggerPolicy.dhall
+{ policy : Optional ./io.argoproj.sensor.v1alpha1.TriggerPolicy.dhall
 , resourceParameters : List ./io.argoproj.sensor.v1alpha1.TriggerParameter.dhall
 , template : ./io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall
 , templateParameters : List ./io.argoproj.sensor.v1alpha1.TriggerParameter.dhall

--- a/src/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall
+++ b/src/kubernetes/argo-events/types/io.argoproj.sensor.v1alpha1.TriggerTemplate.dhall
@@ -1,4 +1,7 @@
 { name : Text
 , source : ./io.argoproj.sensor.v1alpha1.ArtifactLocation.dhall
 , when : Optional ./io.argoproj.sensor.v1alpha1.TriggerCondition.dhall
+, group : Text
+, version : Text
+, resource : Text
 }

--- a/src/kubernetes/argo/package.dhall
+++ b/src/kubernetes/argo/package.dhall
@@ -1,9 +1,5 @@
-{ defaults =
-    ./defaults.dhall
-, types =
-    ./types.dhall
-, typesUnion =
-    ./typesUnion.dhall
-, schemas =
-    ./schemas.dhall 
+{ defaults = ./defaults.dhall
+, types = ./types.dhall
+, typesUnion = ./typesUnion.dhall
+, schemas = ./schemas.dhall
 }

--- a/src/kubernetes/argo/package.dhall
+++ b/src/kubernetes/argo/package.dhall
@@ -1,0 +1,9 @@
+{ defaults =
+    ./defaults.dhall
+, types =
+    ./types.dhall
+, typesUnion =
+    ./typesUnion.dhall
+, schemas =
+    ./schemas.dhall 
+}

--- a/src/kubernetes/package.dhall
+++ b/src/kubernetes/package.dhall
@@ -2,7 +2,7 @@
 , kubernetes-external-secrets = ./kubernetes-external-secrets/package.dhall
 , k8s = ./k8s/package.dhall
 , argocd = ./argocd/package.dhall
-, argo = ./argo/schemas.dhall
-, argo-events = ./argo-events/schemas.dhall
+, argo = ./argo/package.dhall
+, argo-events = ./argo-events/package.dhall
 , ambassador = ./ambassador/package.dhall
 }


### PR DESCRIPTION
- Add sane defaults for 'kind' and 'apiVersion' where relevant
- Make some types optional with None defaults
- Also add package.dhall for argo/argo-events for consistency
- Re-freeze as well (so all relevant changes really in `src/` directory)