### PR TITLE
Rename `type` to `Type` in `CronTab/package.dhall`

### DIFF
--- a/package.dhall
+++ b/package.dhall
@@ -5,6 +5,6 @@
       https://prelude.dhall-lang.org/v12.0.0/package.dhall sha256:aea6817682359ae1939f3a15926b84ad5763c24a3740103202d2eaaea4d01f4c
     ? https://prelude.dhall-lang.org/v12.0.0/package.dhall
 , util =
-      ./util/package.dhall sha256:a4f561f4a468a237e542aa1b74b5696a0da4a9689a6cd0d01841b970281de1ff
+      ./util/package.dhall sha256:72497dc33a20aa8366d403379d22ff59a097b12c18546e7841b8aceb788ad655
     ? ./util/package.dhall
 }

--- a/util/CronTab/package.dhall
+++ b/util/CronTab/package.dhall
@@ -1,7 +1,7 @@
 { default =
       ./default.dhall sha256:a2e2d1f18e5cde460286340094277234b3d9e111334fe9becdc42f06ea7c2fe1
     ? ./default.dhall
-, type =
+, Type =
       ./Type.dhall sha256:96d534737ce8212a4ba983e3477d2b3f797532ac553725713f59d80bdb300e4a
     ? ./Type.dhall
 , show =

--- a/util/package.dhall
+++ b/util/package.dhall
@@ -1,4 +1,4 @@
 { CronTab =
-      ./CronTab/package.dhall sha256:0e38ee5c60705ed2acbcd80947555abb6c2f7092c3956891b3ad4b2e2d6fef00
+      ./CronTab/package.dhall sha256:e6a2fd6070196abc24cf0e4f77100a972710075ac43458ff09bf0619abb45ddc
     ? ./CronTab/package.dhall
 }


### PR DESCRIPTION
Allows the object to be used with `::` sugar.