### PR TITLE
Add DirectorySourceSpec to argocd/package.dhall

### DIFF
--- a/kubernetes/argocd/example/app.dhall
+++ b/kubernetes/argocd/example/app.dhall
@@ -1,5 +1,5 @@
 let argocd =
-        ../package.dhall sha256:da3664e8a089162f27db3d2d552f08e11b923d8546853f20e13f5b9a6d7b26c6
+        ../package.dhall sha256:07fd4ddd04738ba0c7c69e52ee963fcedb28995893f0f801dcf56098a9247ce3
       ? ../package.dhall
 
 let config =

--- a/kubernetes/argocd/example/project.dhall
+++ b/kubernetes/argocd/example/project.dhall
@@ -1,5 +1,5 @@
 let argocd =
-        ../package.dhall sha256:da3664e8a089162f27db3d2d552f08e11b923d8546853f20e13f5b9a6d7b26c6
+        ../package.dhall sha256:07fd4ddd04738ba0c7c69e52ee963fcedb28995893f0f801dcf56098a9247ce3
       ? ../package.dhall
 
 let k8s =

--- a/kubernetes/argocd/package.dhall
+++ b/kubernetes/argocd/package.dhall
@@ -13,6 +13,9 @@
 , Difference =
       ./Difference/package.dhall sha256:51b0dc8cf017e203816d82de76ccd18e786e2e72b101c53ee12194f48d119d53
     ? ./Difference/package.dhall
+, DirectorySourceSpec =
+      ./DirectorySourceSpec/package.dhall sha256:32e62abea32fabf58a8539586c25f93ad355756a52f592d817690eddc8bc057f
+    ? ./DirectorySourceSpec/package.dhall
 , HelmSourceSpec =
       ./HelmSourceSpec/package.dhall sha256:380ded7e9ccb3e786facd647fd0d28bb6df20b9dce93e194413b7f6968a39a53
     ? ./HelmSourceSpec/package.dhall

--- a/kubernetes/package.dhall
+++ b/kubernetes/package.dhall
@@ -8,7 +8,7 @@
       ./k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
     ? ./k8s/package.dhall
 , argocd =
-      ./argocd/package.dhall sha256:da3664e8a089162f27db3d2d552f08e11b923d8546853f20e13f5b9a6d7b26c6
+      ./argocd/package.dhall sha256:37659a96e878f98fa6643ec2db53c17dfc9cc388c3a445a979e0310be12e6611
     ? ./argocd/package.dhall
 , argo =
       ./argo/package.dhall sha256:72c8a8f37f102ba5bff6bf68885d2c8f53817dfa4215b702bb9c544582048fa6

--- a/package.dhall
+++ b/package.dhall
@@ -1,5 +1,5 @@
 { kubernetes =
-      ./kubernetes/package.dhall sha256:e8072181e78223e670c7f08e1392eaa6ed4b397dabf6d2018ad529598242ddcf
+      ./kubernetes/package.dhall sha256:d1933c5434c43cf018f64e3c5d070a6bef1050cc1b03aa851581bae46c034e3f
     ? ./kubernetes/package.dhall
 , Prelude =
       https://prelude.dhall-lang.org/v12.0.0/package.dhall sha256:aea6817682359ae1939f3a15926b84ad5763c24a3740103202d2eaaea4d01f4c


### PR DESCRIPTION
This file was missing from the package object for argocd.