### PR TITLE
Update dhall-kubernetes to latest version and explicitly state k8s version

### DIFF
--- a/kubernetes/ambassador/AuthService/Type.dhall
+++ b/kubernetes/ambassador/AuthService/Type.dhall
@@ -4,12 +4,11 @@
 -}
 
 let k8s =
-        ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-      ? ../../k8s/package.dhall
+        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+      ? ../../k8s/1.14.dhall
 
 in  { apiVersion : Text
-    , kind : Text
-    , metadata : k8s.types.ObjectMeta
+    , kind : k8s.ObjectMeta.Type
     , spec :
           ../AuthServiceSpec/Type.dhall sha256:0088513c5510633ccf632eb63d54fffb7a8236294258f8b50167a0b52d007181
         ? ../AuthServiceSpec/Type.dhall

--- a/kubernetes/ambassador/AuthService/Type.dhall
+++ b/kubernetes/ambassador/AuthService/Type.dhall
@@ -8,7 +8,8 @@ let k8s =
       ? ../../k8s/1.14.dhall
 
 in  { apiVersion : Text
-    , kind : k8s.ObjectMeta.Type
+    , kind : Text
+    , metadata : k8s.ObjectMeta.Type
     , spec :
           ../AuthServiceSpec/Type.dhall sha256:0088513c5510633ccf632eb63d54fffb7a8236294258f8b50167a0b52d007181
         ? ../AuthServiceSpec/Type.dhall

--- a/kubernetes/ambassador/AuthService/package.dhall
+++ b/kubernetes/ambassador/AuthService/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:d73ef227e107707614188021c3c37258b9d2b17dae66adc21c733a366b2c3275
+      ./Type.dhall sha256:fd1a70a84023f29f98bb225902be3442d92302a9205a1ffc9b913c03d8b60a03
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:1ba6e19e9efe37479e887485fd948f45ab988a42ef1edb4a393d8b22ba2eca87

--- a/kubernetes/ambassador/AuthService/package.dhall
+++ b/kubernetes/ambassador/AuthService/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:fd1a70a84023f29f98bb225902be3442d92302a9205a1ffc9b913c03d8b60a03
+      ./Type.dhall sha256:d73ef227e107707614188021c3c37258b9d2b17dae66adc21c733a366b2c3275
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:1ba6e19e9efe37479e887485fd948f45ab988a42ef1edb4a393d8b22ba2eca87

--- a/kubernetes/ambassador/Mapping/Type.dhall
+++ b/kubernetes/ambassador/Mapping/Type.dhall
@@ -9,7 +9,8 @@ let k8s =
       ? ../../k8s/1.14.dhall
 
 in  { apiVersion : Text
-    , kind : k8s.ObjectMeta.Type
+    , kind : Text
+    , metadata : k8s.ObjectMeta.Type
     , spec :
           ../MappingSpec/Type.dhall sha256:51bfe00fdb0a3d21a747714dc6fab5ceab6a2fbd002436c9968c7f728c849d5f
         ? ../MappingSpec/Type.dhall

--- a/kubernetes/ambassador/Mapping/Type.dhall
+++ b/kubernetes/ambassador/Mapping/Type.dhall
@@ -5,12 +5,11 @@
 -}
 
 let k8s =
-        ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-      ? ../../k8s/package.dhall
+        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+      ? ../../k8s/1.14.dhall
 
 in  { apiVersion : Text
-    , kind : Text
-    , metadata : k8s.types.ObjectMeta
+    , kind : k8s.ObjectMeta.Type
     , spec :
           ../MappingSpec/Type.dhall sha256:51bfe00fdb0a3d21a747714dc6fab5ceab6a2fbd002436c9968c7f728c849d5f
         ? ../MappingSpec/Type.dhall

--- a/kubernetes/ambassador/Mapping/package.dhall
+++ b/kubernetes/ambassador/Mapping/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:0e653120b8fa3b2b72f7a7b431bc6112fd298c2c6e7f840fcf1e3bcc328a9011
+      ./Type.dhall sha256:fdc0f198ffb2e46a5605105e0a42a4cb30b09f480e80f1eda0f159b41b273dcc
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:77840fc95c95f5c8ac7d5c7f8a8b64615a3930e4de6e337199951a19324f13ba

--- a/kubernetes/ambassador/Mapping/package.dhall
+++ b/kubernetes/ambassador/Mapping/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:fdc0f198ffb2e46a5605105e0a42a4cb30b09f480e80f1eda0f159b41b273dcc
+      ./Type.dhall sha256:0e653120b8fa3b2b72f7a7b431bc6112fd298c2c6e7f840fcf1e3bcc328a9011
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:77840fc95c95f5c8ac7d5c7f8a8b64615a3930e4de6e337199951a19324f13ba

--- a/kubernetes/ambassador/package.dhall
+++ b/kubernetes/ambassador/package.dhall
@@ -1,5 +1,5 @@
 { AuthService =
-      ./AuthService/package.dhall sha256:ce0835b8d18d4b3befc69de489a4b80b7a4f52c774e50d5c14c9aa7e5725ab2d
+      ./AuthService/package.dhall sha256:38aba5d9403f93dfc41da40bc78950872a8ec03c60b37fb903a110506094be79
     ? ./AuthService/package.dhall
 , AuthServiceIncludeBody =
       ./AuthServiceIncludeBody/package.dhall sha256:4f65364e68fd4e6059f72a338fc50c92c519839c6e9f452dbc0befdc46e0b75f
@@ -32,7 +32,7 @@
       ./LoadbalancerPolicy/package.dhall sha256:4745eec474d5fee647461c62cc5ad690860f16dfa5a9cf19b6763d127ec72c0c
     ? ./LoadbalancerPolicy/package.dhall
 , Mapping =
-      ./Mapping/package.dhall sha256:ced24de0cfdbad58bab33865f2df21dc9dc7cbc8d2abdc111db9a275727d9971
+      ./Mapping/package.dhall sha256:b47cea9243f5ff7ab90e7dcdd8b2822cecf0a39f12cd079ac37c1e6039451510
     ? ./Mapping/package.dhall
 , MappingSpec =
       ./MappingSpec/package.dhall sha256:ac43b68bd088657681858fe761529135357019bfb55faa09cedf85a0df3780ae

--- a/kubernetes/ambassador/package.dhall
+++ b/kubernetes/ambassador/package.dhall
@@ -1,5 +1,5 @@
 { AuthService =
-      ./AuthService/package.dhall sha256:38aba5d9403f93dfc41da40bc78950872a8ec03c60b37fb903a110506094be79
+      ./AuthService/package.dhall sha256:ce0835b8d18d4b3befc69de489a4b80b7a4f52c774e50d5c14c9aa7e5725ab2d
     ? ./AuthService/package.dhall
 , AuthServiceIncludeBody =
       ./AuthServiceIncludeBody/package.dhall sha256:4f65364e68fd4e6059f72a338fc50c92c519839c6e9f452dbc0befdc46e0b75f
@@ -32,7 +32,7 @@
       ./LoadbalancerPolicy/package.dhall sha256:4745eec474d5fee647461c62cc5ad690860f16dfa5a9cf19b6763d127ec72c0c
     ? ./LoadbalancerPolicy/package.dhall
 , Mapping =
-      ./Mapping/package.dhall sha256:b47cea9243f5ff7ab90e7dcdd8b2822cecf0a39f12cd079ac37c1e6039451510
+      ./Mapping/package.dhall sha256:ced24de0cfdbad58bab33865f2df21dc9dc7cbc8d2abdc111db9a275727d9971
     ? ./Mapping/package.dhall
 , MappingSpec =
       ./MappingSpec/package.dhall sha256:ac43b68bd088657681858fe761529135357019bfb55faa09cedf85a0df3780ae

--- a/kubernetes/argo/patch.diff
+++ b/kubernetes/argo/patch.diff
@@ -2957,7 +2957,7 @@ index 0000000..36b9cdc
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.Affinity
+.Affinity.Type
 diff --git a/kubernetes/argo/types/io.k8s.api.core.v1.ConfigMapKeySelector.dhall b/kubernetes/argo/types/io.k8s.api.core.v1.ConfigMapKeySelector.dhall
 new file mode 100644
 index 0000000..924bfeb
@@ -2966,7 +2966,7 @@ index 0000000..924bfeb
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.ConfigMapKeySelector
+.ConfigMapKeySelector.Type
 diff --git a/kubernetes/argo/types/io.k8s.api.core.v1.Container.dhall b/kubernetes/argo/types/io.k8s.api.core.v1.Container.dhall
 new file mode 100644
 index 0000000..044db86
@@ -2975,7 +2975,7 @@ index 0000000..044db86
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.Container
+.Container.Type
 diff --git a/kubernetes/argo/types/io.k8s.api.core.v1.ContainerPort.dhall b/kubernetes/argo/types/io.k8s.api.core.v1.ContainerPort.dhall
 new file mode 100644
 index 0000000..463926f
@@ -2984,7 +2984,7 @@ index 0000000..463926f
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.ContainerPort
+.ContainerPort.Type
 diff --git a/kubernetes/argo/types/io.k8s.api.core.v1.EnvFromSource.dhall b/kubernetes/argo/types/io.k8s.api.core.v1.EnvFromSource.dhall
 new file mode 100644
 index 0000000..7450501
@@ -2993,7 +2993,7 @@ index 0000000..7450501
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.EnvFromSource
+.EnvFromSource.Type
 diff --git a/kubernetes/argo/types/io.k8s.api.core.v1.EnvVar.dhall b/kubernetes/argo/types/io.k8s.api.core.v1.EnvVar.dhall
 new file mode 100644
 index 0000000..90fdb6a
@@ -3002,7 +3002,7 @@ index 0000000..90fdb6a
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.EnvVar
+.EnvVar.Type
 diff --git a/kubernetes/argo/types/io.k8s.api.core.v1.Lifecycle.dhall b/kubernetes/argo/types/io.k8s.api.core.v1.Lifecycle.dhall
 new file mode 100644
 index 0000000..4e61aba
@@ -3011,7 +3011,7 @@ index 0000000..4e61aba
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.Lifecycle
+.Lifecycle.Type
 diff --git a/kubernetes/argo/types/io.k8s.api.core.v1.LocalObjectReference.dhall b/kubernetes/argo/types/io.k8s.api.core.v1.LocalObjectReference.dhall
 new file mode 100644
 index 0000000..53fea9e
@@ -3020,7 +3020,7 @@ index 0000000..53fea9e
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.LocalObjectReference
+.LocalObjectReference.Type
 diff --git a/kubernetes/argo/types/io.k8s.api.core.v1.PersistentVolumeClaim.dhall b/kubernetes/argo/types/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
 new file mode 100644
 index 0000000..22479ad
@@ -3029,7 +3029,7 @@ index 0000000..22479ad
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.PersistentVolumeClaim
+.PersistentVolumeClaim.Type
 diff --git a/kubernetes/argo/types/io.k8s.api.core.v1.PodDNSConfig.dhall b/kubernetes/argo/types/io.k8s.api.core.v1.PodDNSConfig.dhall
 new file mode 100644
 index 0000000..d7d75aa
@@ -3038,7 +3038,7 @@ index 0000000..d7d75aa
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.PodDNSConfig
+.PodDNSConfig.Type
 diff --git a/kubernetes/argo/types/io.k8s.api.core.v1.Probe.dhall b/kubernetes/argo/types/io.k8s.api.core.v1.Probe.dhall
 new file mode 100644
 index 0000000..aa03daf
@@ -3047,7 +3047,7 @@ index 0000000..aa03daf
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.Probe
+.Probe.Type
 diff --git a/kubernetes/argo/types/io.k8s.api.core.v1.ResourceRequirements.dhall b/kubernetes/argo/types/io.k8s.api.core.v1.ResourceRequirements.dhall
 new file mode 100644
 index 0000000..6265210
@@ -3056,7 +3056,7 @@ index 0000000..6265210
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.ResourceRequirements
+.ResourceRequirements.Type
 diff --git a/kubernetes/argo/types/io.k8s.api.core.v1.SecretKeySelector.dhall b/kubernetes/argo/types/io.k8s.api.core.v1.SecretKeySelector.dhall
 new file mode 100644
 index 0000000..c9d01c2
@@ -3065,7 +3065,7 @@ index 0000000..c9d01c2
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.SecretKeySelector
+.SecretKeySelector.Type
 diff --git a/kubernetes/argo/types/io.k8s.api.core.v1.SecurityContext.dhall b/kubernetes/argo/types/io.k8s.api.core.v1.SecurityContext.dhall
 new file mode 100644
 index 0000000..a6ff6a1
@@ -3074,7 +3074,7 @@ index 0000000..a6ff6a1
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.SecurityContext
+.SecurityContext.Type
 diff --git a/kubernetes/argo/types/io.k8s.api.core.v1.Toleration.dhall b/kubernetes/argo/types/io.k8s.api.core.v1.Toleration.dhall
 new file mode 100644
 index 0000000..c75e2c2
@@ -3083,7 +3083,7 @@ index 0000000..c75e2c2
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.Toleration
+.Toleration.Type
 diff --git a/kubernetes/argo/types/io.k8s.api.core.v1.Volume.dhall b/kubernetes/argo/types/io.k8s.api.core.v1.Volume.dhall
 new file mode 100644
 index 0000000..a101d31
@@ -3092,7 +3092,7 @@ index 0000000..a101d31
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.Volume
+.Volume.Type
 diff --git a/kubernetes/argo/types/io.k8s.api.core.v1.VolumeDevice.dhall b/kubernetes/argo/types/io.k8s.api.core.v1.VolumeDevice.dhall
 new file mode 100644
 index 0000000..16442a6
@@ -3101,7 +3101,7 @@ index 0000000..16442a6
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.VolumeDevice
+.VolumeDevice.Type
 diff --git a/kubernetes/argo/types/io.k8s.api.core.v1.VolumeMount.dhall b/kubernetes/argo/types/io.k8s.api.core.v1.VolumeMount.dhall
 new file mode 100644
 index 0000000..8f03b5b
@@ -3110,7 +3110,7 @@ index 0000000..8f03b5b
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.VolumeMount
+.VolumeMount.Type
 diff --git a/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta.dhall b/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta.dhall
 new file mode 100644
 index 0000000..daa49d3
@@ -3119,7 +3119,7 @@ index 0000000..daa49d3
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.ListMeta
+.ListMeta.Type
 diff --git a/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall b/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 new file mode 100644
 index 0000000..e536240
@@ -3128,7 +3128,7 @@ index 0000000..e536240
 @@ -0,0 +1,3 @@
 +(   ../../k8s/package.dhall sha256:4c9c40f1762e95578c86c3efbccb87ce74ff67c5111a4c92c4393c6d163bb51b
 +  ? ../../k8s/package.dhall
-+).types.ObjectMeta
+.ObjectMeta.Type
 diff --git a/kubernetes/argo/typesUnion.dhall b/kubernetes/argo/typesUnion.dhall
 index f462d2c..ab888b7 100644
 --- a/kubernetes/argo/typesUnion.dhall

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Affinity.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Affinity.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.Affinity
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).Affinity.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.ConfigMapKeySelector.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.ConfigMapKeySelector.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.ConfigMapKeySelector
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).ConfigMapKeySelector.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Container.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Container.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.Container
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).Container.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.ContainerPort.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.ContainerPort.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.ContainerPort
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).ContainerPort.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.EnvFromSource.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.EnvFromSource.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.EnvFromSource
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).EnvFromSource.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.EnvVar.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.EnvVar.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.EnvVar
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).EnvVar.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Lifecycle.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Lifecycle.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.Lifecycle
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).Lifecycle.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.LocalObjectReference.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.LocalObjectReference.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.LocalObjectReference
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).LocalObjectReference.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.PersistentVolumeClaim
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).PersistentVolumeClaim.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.PodDNSConfig.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.PodDNSConfig.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.PodDNSConfig
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).PodDNSConfig.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Probe.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Probe.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.Probe
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).Probe.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.ResourceRequirements.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.ResourceRequirements.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.ResourceRequirements
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).ResourceRequirements.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.SecretKeySelector.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.SecretKeySelector.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.SecretKeySelector
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).SecretKeySelector.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.SecurityContext.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.SecurityContext.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.SecurityContext
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).SecurityContext.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Toleration.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Toleration.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.Toleration
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).Toleration.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Volume.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Volume.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.Volume
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).Volume.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.VolumeDevice.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.VolumeDevice.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.VolumeDevice
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).VolumeDevice.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.VolumeMount.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.VolumeMount.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.VolumeMount
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).VolumeMount.Type

--- a/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta.dhall
+++ b/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.ListMeta
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).ListMeta.Type

--- a/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+++ b/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-  ? ../../k8s/package.dhall
-).types.ObjectMeta
+(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+  ? ../../k8s/1.14.dhall
+).ObjectMeta.Type

--- a/kubernetes/argocd/Application/Type.dhall
+++ b/kubernetes/argocd/Application/Type.dhall
@@ -1,9 +1,10 @@
 let k8s =
-      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/4ad58156b7fdbbb6da0543d8b314df899feca077/types.dhall sha256:e48e21b807dad217a6c3e631fcaf3e950062310bfb4a8bbcecc330eb7b2f60ed
+        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+      ? ../../k8s/1.14.dhall
 
 in  { apiVersion : Text
     , kind : Text
-    , metadata : k8s.ObjectMeta
+    , metadata : k8s.ObjectMeta.Type
     , spec :
           ../ApplicationSpec/Type.dhall sha256:9f25eb2d8fa2e5fbc80f90935d7e59d23a053eadb55f6cd52931fa9708ebde82
         ? ../ApplicationSpec/Type.dhall

--- a/kubernetes/argocd/example/app.dhall
+++ b/kubernetes/argocd/example/app.dhall
@@ -1,5 +1,5 @@
 let argocd =
-        ../package.dhall sha256:07fd4ddd04738ba0c7c69e52ee963fcedb28995893f0f801dcf56098a9247ce3
+        ../package.dhall sha256:37659a96e878f98fa6643ec2db53c17dfc9cc388c3a445a979e0310be12e6611
       ? ../package.dhall
 
 let config =

--- a/kubernetes/argocd/example/project.dhall
+++ b/kubernetes/argocd/example/project.dhall
@@ -1,15 +1,15 @@
 let argocd =
-        ../package.dhall sha256:07fd4ddd04738ba0c7c69e52ee963fcedb28995893f0f801dcf56098a9247ce3
+        ../package.dhall sha256:37659a96e878f98fa6643ec2db53c17dfc9cc388c3a445a979e0310be12e6611
       ? ../package.dhall
 
 let k8s =
-        ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-      ? ../../k8s/package.dhall
+        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+      ? ../../k8s/1.14.dhall
 
 in  argocd.TypesUnion.Project
       argocd.Project::{
       , metadata =
-          k8s.schemas.ObjectMeta::{
+          k8s.ObjectMeta::{
           , name =
                 ./projectName.dhall sha256:d7e4e24f5750f02229d03a034faabf0f3378960c20170d83e78ab83c1131aded
               ? ./projectName.dhall

--- a/kubernetes/argocd/util/internal/makeDhallApp.dhall
+++ b/kubernetes/argocd/util/internal/makeDhallApp.dhall
@@ -29,8 +29,8 @@ let PluginSpec =
       ? ../../PluginSpec/package.dhall
 
 let k8s =
-        ../../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-      ? ../../../k8s/package.dhall
+        ../../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+      ? ../../../k8s/1.14.dhall
 
 in      \ ( appConfig
           :   ../DhallAppConfig/Type.dhall sha256:b870b087d04ed906a4b912f2333e66fd43db05bdcea36740a6cd707a380b4a72
@@ -38,7 +38,7 @@ in      \ ( appConfig
           )
     ->    TypesUnion.Application
             Application::{
-            , metadata = k8s.schemas.ObjectMeta::{ name = appConfig.name }
+            , metadata = k8s.ObjectMeta::{ name = appConfig.name }
             , spec =
                 ApplicationSpec::{
                 , project = appConfig.project

--- a/kubernetes/argocd/util/internal/makeHelmApp.dhall
+++ b/kubernetes/argocd/util/internal/makeHelmApp.dhall
@@ -23,8 +23,8 @@ let HelmSpec =
       ? ../../HelmSpec/package.dhall
 
 let k8s =
-        ../../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-      ? ../../../k8s/package.dhall
+        ../../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+      ? ../../../k8s/1.14.dhall
 
 in      \ ( appConfig
           :   ../HelmAppConfig/Type.dhall sha256:a58dc0d542f24958d2f4e4a208317531b749574a35cca08dbf123d059234a02e
@@ -32,7 +32,7 @@ in      \ ( appConfig
           )
     ->    TypesUnion.Application
             Application::{
-            , metadata = k8s.schemas.ObjectMeta::{ name = appConfig.name }
+            , metadata = k8s.ObjectMeta::{ name = appConfig.name }
             , spec =
                 ApplicationSpec::{
                 , project = appConfig.project

--- a/kubernetes/argocd/util/internal/makeKustomizeApp.dhall
+++ b/kubernetes/argocd/util/internal/makeKustomizeApp.dhall
@@ -23,8 +23,8 @@ let KustomizeSpec =
       ? ../../KustomizeSpec/package.dhall
 
 let k8s =
-        ../../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-      ? ../../../k8s/package.dhall
+        ../../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+      ? ../../../k8s/1.14.dhall
 
 in      \ ( appConfig
           :   ../KustomizeAppConfig/Type.dhall sha256:4a3f8913366c0ac644abbb39626a3b2df997d07fc23a1754d262998c44d89908
@@ -32,7 +32,7 @@ in      \ ( appConfig
           )
     ->    TypesUnion.Application
             Application::{
-            , metadata = k8s.schemas.ObjectMeta::{ name = appConfig.name }
+            , metadata = k8s.ObjectMeta::{ name = appConfig.name }
             , spec =
                 ApplicationSpec::{
                 , project = appConfig.project

--- a/kubernetes/argocd/util/withSyncWave.dhall
+++ b/kubernetes/argocd/util/withSyncWave.dhall
@@ -2,8 +2,8 @@
     Utility to add sync waves to argocd applications and projects.
 -}
 let k8s =
-        ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-      ? ../../k8s/package.dhall
+        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+      ? ../../k8s/1.14.dhall
 
 let Project =
         ../Project/package.dhall sha256:43e36b1dc0eec92d602643cbee9b21bf5d27b8912cabf8d88a1776b5a5b1f7d8
@@ -19,7 +19,7 @@ let TypesUnion =
 
 let withSyncWaveMetadata =
           \(wave : Integer)
-      ->  \(metadata : k8s.types.ObjectMeta)
+      ->  \(metadata : k8s.ObjectMeta.Type)
       ->      metadata
           //  { annotations =
                     metadata.annotations

--- a/kubernetes/cert-manager/Certificate/Type.dhall
+++ b/kubernetes/cert-manager/Certificate/Type.dhall
@@ -1,10 +1,10 @@
 let k8s =
-        ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-      ? ../../k8s/package.dhall
+        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+      ? ../../k8s/1.14.dhall
 
 in  { apiVersion : Text
     , kind : Text
-    , metadata : k8s.types.ObjectMeta
+    , metadata : k8s.ObjectMeta.Type
     , spec :
           ../CertificateSpec/Type.dhall sha256:b2e8063917b59c690a925ed4eccf9f68d012667602b205533472b3874d485d32
         ? ../CertificateSpec/Type.dhall

--- a/kubernetes/cert-manager/ClusterIssuer/Type.dhall
+++ b/kubernetes/cert-manager/ClusterIssuer/Type.dhall
@@ -1,9 +1,9 @@
 let k8s =
-        ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-      ? ../../k8s/package.dhall
+        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+      ? ../../k8s/1.14.dhall
 
 in  { apiVersion : Text
     , kind : Text
-    , metadata : k8s.types.ObjectMeta
+    , metadata : k8s.ObjectMeta.Type
     , spec : { ca : { secretName : Text } }
     }

--- a/kubernetes/k8s/1.14.dhall
+++ b/kubernetes/k8s/1.14.dhall
@@ -1,0 +1,2 @@
+  https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.14/package.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+? https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.14/package.dhall

--- a/kubernetes/k8s/1.15.dhall
+++ b/kubernetes/k8s/1.15.dhall
@@ -1,0 +1,2 @@
+  https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.15/package.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+? https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.15/package.dhall

--- a/kubernetes/k8s/1.16.dhall
+++ b/kubernetes/k8s/1.16.dhall
@@ -1,0 +1,2 @@
+  https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.16/package.dhall sha256:ab1c971ddeb178c1cfc5e749b211b4fe6fdb6fa1b68b10de62aeb543efcd60b3
+? https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.16/package.dhall

--- a/kubernetes/k8s/1.17.dhall
+++ b/kubernetes/k8s/1.17.dhall
@@ -1,0 +1,2 @@
+  https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.14/package.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+? https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.14/package.dhall

--- a/kubernetes/k8s/package.dhall
+++ b/kubernetes/k8s/package.dhall
@@ -1,9 +1,13 @@
-{ defaults =
-    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/defaults.dhall sha256:98bf62170e7785da6f627a06980c5788a5b8bdd0d1e61bb7c141beef18a3129c
-, types =
-    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/types.dhall sha256:e48e21b807dad217a6c3e631fcaf3e950062310bfb4a8bbcecc330eb7b2f60ed
-, typesUnion =
-    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/typesUnion.dhall sha256:8e8db456b218b93f8241d497e54d07214b132523fe84263e6c03496c141a8b18
-, schemas =
-    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/fee24c0993ba0b20190e2fdb94e386b7fb67252d/schemas.dhall sha256:0a362a64a631fe7911f71438fa05acdcdf6469850cce4f910e4cf126315d1011
+{ `1-14` =
+      ./1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+    ? ./1.14.dhall
+, `1-15` =
+      ./1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+    ? ./1.15.dhall
+, `1-16` =
+      ./1.16.dhall sha256:ab1c971ddeb178c1cfc5e749b211b4fe6fdb6fa1b68b10de62aeb543efcd60b3
+    ? ./1.16.dhall
+, `1-17` =
+      ./1.17.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+    ? ./1.17.dhall
 }

--- a/kubernetes/kubernetes-external-secrets/ExternalSecret/Type.dhall
+++ b/kubernetes/kubernetes-external-secrets/ExternalSecret/Type.dhall
@@ -1,10 +1,10 @@
 let k8s =
-        ../../k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
-      ? ../../k8s/package.dhall
+        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+      ? ../../k8s/1.14.dhall
 
 in  { apiVersion : Text
     , kind : Text
-    , metadata : k8s.types.ObjectMeta
+    , metadata : k8s.ObjectMeta.Type
     , secretDescriptor :
           ../SecretDescriptor.dhall sha256:723bd48b2b27aa12fbd996b865027501b1e7568f5238f45a7171979748c2ec7e
         ? ../SecretDescriptor.dhall

--- a/kubernetes/package.dhall
+++ b/kubernetes/package.dhall
@@ -5,7 +5,7 @@
       ./kubernetes-external-secrets/package.dhall sha256:80f9cd5625bf7fa2eb87b67627d712062194a85e1b399f4ed0efa03aaac68b27
     ? ./kubernetes-external-secrets/package.dhall
 , k8s =
-      ./k8s/package.dhall sha256:4159b87d109cd88610c9d440701091d6fdd718d81aba5691e2d6ed7c93fbcd09
+      ./k8s/package.dhall sha256:4b575d18387671adf3e3b1db4fe7fa6ff880c26c8c69082176b4ef84dee2e4d6
     ? ./k8s/package.dhall
 , argocd =
       ./argocd/package.dhall sha256:37659a96e878f98fa6643ec2db53c17dfc9cc388c3a445a979e0310be12e6611
@@ -17,6 +17,6 @@
       ./argo-events/package.dhall sha256:06fdc660a4abfc141641cfc58855ad52192b9f93d4d8edbaae2f9aba77d1efc7
     ? ./argo-events/package.dhall
 , ambassador =
-      ./ambassador/package.dhall sha256:5aaed07cae5f55f7a989ec39240716e6f9656c47681c552aca8fd138aaf14bcf
+      ./ambassador/package.dhall sha256:f26db375f5c23e7dc58c96a925b56f6cb3372b062ace25502dd614d666d3287b
     ? ./ambassador/package.dhall
 }

--- a/kubernetes/package.dhall
+++ b/kubernetes/package.dhall
@@ -17,6 +17,6 @@
       ./argo-events/package.dhall sha256:06fdc660a4abfc141641cfc58855ad52192b9f93d4d8edbaae2f9aba77d1efc7
     ? ./argo-events/package.dhall
 , ambassador =
-      ./ambassador/package.dhall sha256:f26db375f5c23e7dc58c96a925b56f6cb3372b062ace25502dd614d666d3287b
+      ./ambassador/package.dhall sha256:5aaed07cae5f55f7a989ec39240716e6f9656c47681c552aca8fd138aaf14bcf
     ? ./ambassador/package.dhall
 }

--- a/package.dhall
+++ b/package.dhall
@@ -1,5 +1,5 @@
 { kubernetes =
-      ./kubernetes/package.dhall sha256:cb154733666bd5367ff13cd94b5d5ec9d31f37d498acb458c54a60458efc8f2d
+      ./kubernetes/package.dhall sha256:18587ed93cedd64b79447abf22c5c20722aca8981a4b8ab2f29a10721193f7ad
     ? ./kubernetes/package.dhall
 , Prelude =
       https://prelude.dhall-lang.org/v12.0.0/package.dhall sha256:aea6817682359ae1939f3a15926b84ad5763c24a3740103202d2eaaea4d01f4c

--- a/package.dhall
+++ b/package.dhall
@@ -1,5 +1,5 @@
 { kubernetes =
-      ./kubernetes/package.dhall sha256:d1933c5434c43cf018f64e3c5d070a6bef1050cc1b03aa851581bae46c034e3f
+      ./kubernetes/package.dhall sha256:cb154733666bd5367ff13cd94b5d5ec9d31f37d498acb458c54a60458efc8f2d
     ? ./kubernetes/package.dhall
 , Prelude =
       https://prelude.dhall-lang.org/v12.0.0/package.dhall sha256:aea6817682359ae1939f3a15926b84ad5763c24a3740103202d2eaaea4d01f4c


### PR DESCRIPTION
This updates `dhall-packages` to use the latest improvements on `dhall-kubernetes`. 

I also added the future versions of Kubernetes for easier discovery, but all our templates will be based off 1.14 (this should not be a problem because we are using them for stable objects)