### PR TITLE
Add more options to kubernetes-external-secrets

### DIFF
--- a/kubernetes/kubernetes-external-secrets/ExternalSecret/Type.dhall
+++ b/kubernetes/kubernetes-external-secrets/ExternalSecret/Type.dhall
@@ -6,6 +6,6 @@ in  { apiVersion : Text
     , kind : Text
     , metadata : k8s.ObjectMeta.Type
     , secretDescriptor :
-          ../SecretDescriptor.dhall sha256:723bd48b2b27aa12fbd996b865027501b1e7568f5238f45a7171979748c2ec7e
+          ../SecretDescriptor.dhall sha256:18b8c67891d7abc2ed14004239b24f39cd62748da25ceca73788d29f466c48a2
         ? ../SecretDescriptor.dhall
     }

--- a/kubernetes/kubernetes-external-secrets/SecretDescriptor.dhall
+++ b/kubernetes/kubernetes-external-secrets/SecretDescriptor.dhall
@@ -1,5 +1,5 @@
 < SecretsManagerSecretDescriptor :
-      ./SecretsManagerSecretDescriptor/Type.dhall sha256:d3a1bd59ce499444aff3bbdd5489800abffbeedeb6721af411223cbf1054125b
+      ./SecretsManagerSecretDescriptor/Type.dhall sha256:6feaa8bc2741d07fd9bf2bd1e09e57661978c2c9b720b071c2949d971552fcfd
     ? ./SecretsManagerSecretDescriptor/Type.dhall
 | SystemManagerSecretDescriptor :
       ./SystemManagerSecretDescriptor/Type.dhall sha256:7cd9738e468bdd65289f078162a0d4724cb62e91d7439576064d636322aedd62

--- a/kubernetes/kubernetes-external-secrets/SecretDescriptor.dhall
+++ b/kubernetes/kubernetes-external-secrets/SecretDescriptor.dhall
@@ -1,5 +1,5 @@
 < SecretsManagerSecretDescriptor :
-      ./SecretsManagerSecretDescriptor/Type.dhall sha256:ade2dc6e1367dd2bbfe9266ae93ffca3b507c5dcdf37acfa12420c11c886ad34
+      ./SecretsManagerSecretDescriptor/Type.dhall sha256:d3a1bd59ce499444aff3bbdd5489800abffbeedeb6721af411223cbf1054125b
     ? ./SecretsManagerSecretDescriptor/Type.dhall
 | SystemManagerSecretDescriptor :
       ./SystemManagerSecretDescriptor/Type.dhall sha256:7cd9738e468bdd65289f078162a0d4724cb62e91d7439576064d636322aedd62

--- a/kubernetes/kubernetes-external-secrets/SecretsManagerExternalData/Type.dhall
+++ b/kubernetes/kubernetes-external-secrets/SecretsManagerExternalData/Type.dhall
@@ -1,1 +1,1 @@
-{ key : Text, name : Text, property : Text }
+{ key : Text, name : Text, property : Optional Text }

--- a/kubernetes/kubernetes-external-secrets/SecretsManagerExternalData/package.dhall
+++ b/kubernetes/kubernetes-external-secrets/SecretsManagerExternalData/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:e6a8a0da8cc20ed4f880bd98a641988de5386e650d472ef1c8cce90932383ba3
+      ./Type.dhall sha256:5b356dfacb979cfcb22842c1e73d2185c0f241ede4bcddc6f4614c35c1afae11
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b

--- a/kubernetes/kubernetes-external-secrets/SecretsManagerSecretDescriptor/Type.dhall
+++ b/kubernetes/kubernetes-external-secrets/SecretsManagerSecretDescriptor/Type.dhall
@@ -6,4 +6,5 @@
       (   ../SecretsManagerExternalData/Type.dhall sha256:5b356dfacb979cfcb22842c1e73d2185c0f241ede4bcddc6f4614c35c1afae11
         ? ../SecretsManagerExternalData/Type.dhall
       )
+, dataFrom : List Text
 }

--- a/kubernetes/kubernetes-external-secrets/SecretsManagerSecretDescriptor/Type.dhall
+++ b/kubernetes/kubernetes-external-secrets/SecretsManagerSecretDescriptor/Type.dhall
@@ -3,7 +3,7 @@
     ? ../BackendType/Type.dhall
 , data :
     List
-      (   ../SecretsManagerExternalData/Type.dhall sha256:e6a8a0da8cc20ed4f880bd98a641988de5386e650d472ef1c8cce90932383ba3
+      (   ../SecretsManagerExternalData/Type.dhall sha256:5b356dfacb979cfcb22842c1e73d2185c0f241ede4bcddc6f4614c35c1afae11
         ? ../SecretsManagerExternalData/Type.dhall
       )
 }

--- a/kubernetes/kubernetes-external-secrets/SecretsManagerSecretDescriptor/default.dhall
+++ b/kubernetes/kubernetes-external-secrets/SecretsManagerSecretDescriptor/default.dhall
@@ -2,4 +2,5 @@
     (   ../BackendType/Type.dhall sha256:7b7b4f32eaef6f79b5c618263a3911544ec9099953d9566538845671a628acd9
       ? ../BackendType/Type.dhall
     ).secretsManager
+, dataFrom = [] : List Text
 }

--- a/kubernetes/kubernetes-external-secrets/SecretsManagerSecretDescriptor/package.dhall
+++ b/kubernetes/kubernetes-external-secrets/SecretsManagerSecretDescriptor/package.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./Type.dhall sha256:ade2dc6e1367dd2bbfe9266ae93ffca3b507c5dcdf37acfa12420c11c886ad34
+      ./Type.dhall sha256:6feaa8bc2741d07fd9bf2bd1e09e57661978c2c9b720b071c2949d971552fcfd
     ? ./Type.dhall
 , default =
-      ./default.dhall sha256:501a7cdf3c4885c1d861bda3e5bbdc75b2eb1081acac2d2a92752a4087d88230
+      ./default.dhall sha256:ed0fb0918548aa999b39470827025913682a8d3618a446d4a8874cd46a466167
     ? ./default.dhall
 }

--- a/kubernetes/kubernetes-external-secrets/package.dhall
+++ b/kubernetes/kubernetes-external-secrets/package.dhall
@@ -5,7 +5,7 @@
       ./ExternalSecret/package.dhall sha256:1faeccea0701f13f5cf42dd76fa109f0a034e9c80ea9c2484cc0d8c6371c6578
     ? ./ExternalSecret/package.dhall
 , SecretsManagerExternalData =
-      ./SecretsManagerExternalData/package.dhall sha256:4fc3cc01529eb9817d773b75827f3fae1a96305e9dea1cfff40b710a81556377
+      ./SecretsManagerExternalData/package.dhall sha256:ce6b73c2cd3abbb9ed7395fdb9fc0e5caea061312813263c230a581fe19653ce
     ? ./SecretsManagerExternalData/package.dhall
 , SystemManagerExternalData =
       ./SystemManagerExternalData/package.dhall sha256:4af8373b25d3ddaaf9d90aa0e47412f18b621b3f09473a2270dd905082d51465

--- a/kubernetes/kubernetes-external-secrets/package.dhall
+++ b/kubernetes/kubernetes-external-secrets/package.dhall
@@ -11,10 +11,10 @@
       ./SystemManagerExternalData/package.dhall sha256:4af8373b25d3ddaaf9d90aa0e47412f18b621b3f09473a2270dd905082d51465
     ? ./SystemManagerExternalData/package.dhall
 , SecretDescriptor =
-      ./SecretDescriptor.dhall sha256:723bd48b2b27aa12fbd996b865027501b1e7568f5238f45a7171979748c2ec7e
+      ./SecretDescriptor.dhall sha256:18b8c67891d7abc2ed14004239b24f39cd62748da25ceca73788d29f466c48a2
     ? ./SecretDescriptor.dhall
 , SecretsManagerSecretDescriptor =
-      ./SecretsManagerSecretDescriptor/package.dhall sha256:99c7730a56295bda9a7a7cb97004d08d1d113bb85f74d7013328b0fb04935219
+      ./SecretsManagerSecretDescriptor/package.dhall sha256:32f2072161a250f6797032bb26d903001ccd570301539d30b50a67431f97f44c
     ? ./SecretsManagerSecretDescriptor/package.dhall
 , SystemManagerSecretDescriptor =
       ./SystemManagerSecretDescriptor/package.dhall sha256:5e504c0b997eb9523fe8e8ff7a92bd6878e2e24673e84e701eb88bc40c96db87

--- a/kubernetes/package.dhall
+++ b/kubernetes/package.dhall
@@ -2,7 +2,7 @@
       ./cert-manager/package.dhall sha256:2f5a8a61e8259bf6d105cab504de2c7ec9a9f004c8c6e0c4a7e773595e800de3
     ? ./cert-manager/package.dhall
 , kubernetes-external-secrets =
-      ./kubernetes-external-secrets/package.dhall sha256:855cd3d8bf02162ebe2193711ccd35653b2b10f4fe7c81c3f0a42a369734bf29
+      ./kubernetes-external-secrets/package.dhall sha256:3b0df58d1d5dc7e8d5971ee06902d30b2eba9608c551779792ec2f3257c494cc
     ? ./kubernetes-external-secrets/package.dhall
 , k8s =
       ./k8s/package.dhall sha256:4b575d18387671adf3e3b1db4fe7fa6ff880c26c8c69082176b4ef84dee2e4d6

--- a/kubernetes/package.dhall
+++ b/kubernetes/package.dhall
@@ -2,7 +2,7 @@
       ./cert-manager/package.dhall sha256:2f5a8a61e8259bf6d105cab504de2c7ec9a9f004c8c6e0c4a7e773595e800de3
     ? ./cert-manager/package.dhall
 , kubernetes-external-secrets =
-      ./kubernetes-external-secrets/package.dhall sha256:80f9cd5625bf7fa2eb87b67627d712062194a85e1b399f4ed0efa03aaac68b27
+      ./kubernetes-external-secrets/package.dhall sha256:855cd3d8bf02162ebe2193711ccd35653b2b10f4fe7c81c3f0a42a369734bf29
     ? ./kubernetes-external-secrets/package.dhall
 , k8s =
       ./k8s/package.dhall sha256:4b575d18387671adf3e3b1db4fe7fa6ff880c26c8c69082176b4ef84dee2e4d6

--- a/package.dhall
+++ b/package.dhall
@@ -1,5 +1,5 @@
 { kubernetes =
-      ./kubernetes/package.dhall sha256:18587ed93cedd64b79447abf22c5c20722aca8981a4b8ab2f29a10721193f7ad
+      ./kubernetes/package.dhall sha256:8886725c371bca6454749a797fb388386c9cc224f8420c378426f014f911b72c
     ? ./kubernetes/package.dhall
 , Prelude =
       https://prelude.dhall-lang.org/v12.0.0/package.dhall sha256:aea6817682359ae1939f3a15926b84ad5763c24a3740103202d2eaaea4d01f4c

--- a/package.dhall
+++ b/package.dhall
@@ -1,5 +1,5 @@
 { kubernetes =
-      ./kubernetes/package.dhall sha256:8886725c371bca6454749a797fb388386c9cc224f8420c378426f014f911b72c
+      ./kubernetes/package.dhall sha256:7b9f076c5655f4a66536314b825cbc2902e3172fbd9b6aa834d1c01c12af7b6f
     ? ./kubernetes/package.dhall
 , Prelude =
       https://prelude.dhall-lang.org/v12.0.0/package.dhall sha256:aea6817682359ae1939f3a15926b84ad5763c24a3740103202d2eaaea4d01f4c


### PR DESCRIPTION
This makes the `property` optional to support plaintext secrets, and the `dataFrom` parameter for convenience