### PR TITLE
Fix self signed cert

### DIFF
--- a/kubernetes/cert-manager/ClusterIssuer/Type.dhall
+++ b/kubernetes/cert-manager/ClusterIssuer/Type.dhall
@@ -5,7 +5,5 @@ let k8s =
 in  { apiVersion : Text
     , kind : Text
     , metadata : k8s.ObjectMeta.Type
-    , spec :
-          ../IssuerSpec/Type.dhall sha256:a444f78e67974acf5936a24860a1913872122003e42732c6c84391f00dc7d2df
-        ? ../IssuerSpec/Type.dhall
+    , spec : ../IssuerSpec/Type.dhall
     }

--- a/kubernetes/cert-manager/ClusterIssuer/Type.dhall
+++ b/kubernetes/cert-manager/ClusterIssuer/Type.dhall
@@ -6,6 +6,6 @@ in  { apiVersion : Text
     , kind : Text
     , metadata : k8s.ObjectMeta.Type
     , spec :
-          ../IssuerSpec/Type.dhall sha256:b81456f409531fce51beff9dd60ff6b8d1de8227e9bc5077fe7e8061707624ff
+          ../IssuerSpec/Type.dhall sha256:a444f78e67974acf5936a24860a1913872122003e42732c6c84391f00dc7d2df
         ? ../IssuerSpec/Type.dhall
     }

--- a/kubernetes/cert-manager/ClusterIssuer/Type.dhall
+++ b/kubernetes/cert-manager/ClusterIssuer/Type.dhall
@@ -5,5 +5,7 @@ let k8s =
 in  { apiVersion : Text
     , kind : Text
     , metadata : k8s.ObjectMeta.Type
-    , spec : ../IssuerSpec/Type.dhall
+    , spec :
+          ../IssuerSpec/Type.dhall sha256:a444f78e67974acf5936a24860a1913872122003e42732c6c84391f00dc7d2df
+        ? ../IssuerSpec/Type.dhall
     }

--- a/kubernetes/cert-manager/ClusterIssuer/package.dhall
+++ b/kubernetes/cert-manager/ClusterIssuer/package.dhall
@@ -1,6 +1,4 @@
-{ Type =
-      ./Type.dhall sha256:555218cba77ee86d2e2d04b9517da72a44cef92f8bd1b11d307829f2d57f9618
-    ? ./Type.dhall
+{ Type = ./Type.dhall
 , default =
       ./default.dhall sha256:2df5bda09440cc131439aeec0eb53b61b38946d8e20facea2adedb56ae80db81
     ? ./default.dhall

--- a/kubernetes/cert-manager/ClusterIssuer/package.dhall
+++ b/kubernetes/cert-manager/ClusterIssuer/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:394d803fd1686a7c72d97bdeb1d65c05e28f84ae8d34c7558890a93ae579d25e
+      ./Type.dhall sha256:555218cba77ee86d2e2d04b9517da72a44cef92f8bd1b11d307829f2d57f9618
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:2df5bda09440cc131439aeec0eb53b61b38946d8e20facea2adedb56ae80db81

--- a/kubernetes/cert-manager/ClusterIssuer/package.dhall
+++ b/kubernetes/cert-manager/ClusterIssuer/package.dhall
@@ -1,4 +1,6 @@
-{ Type = ./Type.dhall
+{ Type =
+      ./Type.dhall sha256:555218cba77ee86d2e2d04b9517da72a44cef92f8bd1b11d307829f2d57f9618
+    ? ./Type.dhall
 , default =
       ./default.dhall sha256:2df5bda09440cc131439aeec0eb53b61b38946d8e20facea2adedb56ae80db81
     ? ./default.dhall

--- a/kubernetes/cert-manager/Issuer/Type.dhall
+++ b/kubernetes/cert-manager/Issuer/Type.dhall
@@ -5,7 +5,5 @@ let k8s =
 in  { apiVersion : Text
     , kind : Text
     , metadata : k8s.ObjectMeta.Type
-    , spec :
-          ../IssuerSpec/Type.dhall sha256:a444f78e67974acf5936a24860a1913872122003e42732c6c84391f00dc7d2df
-        ? ../IssuerSpec/Type.dhall
+    , spec : ../IssuerSpec/Type.dhall
     }

--- a/kubernetes/cert-manager/Issuer/Type.dhall
+++ b/kubernetes/cert-manager/Issuer/Type.dhall
@@ -6,6 +6,6 @@ in  { apiVersion : Text
     , kind : Text
     , metadata : k8s.ObjectMeta.Type
     , spec :
-          ../IssuerSpec/Type.dhall sha256:b81456f409531fce51beff9dd60ff6b8d1de8227e9bc5077fe7e8061707624ff
+          ../IssuerSpec/Type.dhall sha256:a444f78e67974acf5936a24860a1913872122003e42732c6c84391f00dc7d2df
         ? ../IssuerSpec/Type.dhall
     }

--- a/kubernetes/cert-manager/Issuer/Type.dhall
+++ b/kubernetes/cert-manager/Issuer/Type.dhall
@@ -5,5 +5,7 @@ let k8s =
 in  { apiVersion : Text
     , kind : Text
     , metadata : k8s.ObjectMeta.Type
-    , spec : ../IssuerSpec/Type.dhall
+    , spec :
+          ../IssuerSpec/Type.dhall sha256:a444f78e67974acf5936a24860a1913872122003e42732c6c84391f00dc7d2df
+        ? ../IssuerSpec/Type.dhall
     }

--- a/kubernetes/cert-manager/Issuer/package.dhall
+++ b/kubernetes/cert-manager/Issuer/package.dhall
@@ -1,6 +1,4 @@
-{ Type =
-      ./Type.dhall sha256:555218cba77ee86d2e2d04b9517da72a44cef92f8bd1b11d307829f2d57f9618
-    ? ./Type.dhall
+{ Type = ./Type.dhall
 , default =
       ./default.dhall sha256:066a3a656894ad4817e764584a465e6749d14ca2b608673280cb87bafb4e7dde
     ? ./default.dhall

--- a/kubernetes/cert-manager/Issuer/package.dhall
+++ b/kubernetes/cert-manager/Issuer/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:394d803fd1686a7c72d97bdeb1d65c05e28f84ae8d34c7558890a93ae579d25e
+      ./Type.dhall sha256:555218cba77ee86d2e2d04b9517da72a44cef92f8bd1b11d307829f2d57f9618
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:066a3a656894ad4817e764584a465e6749d14ca2b608673280cb87bafb4e7dde

--- a/kubernetes/cert-manager/Issuer/package.dhall
+++ b/kubernetes/cert-manager/Issuer/package.dhall
@@ -1,4 +1,6 @@
-{ Type = ./Type.dhall
+{ Type =
+      ./Type.dhall sha256:555218cba77ee86d2e2d04b9517da72a44cef92f8bd1b11d307829f2d57f9618
+    ? ./Type.dhall
 , default =
       ./default.dhall sha256:066a3a656894ad4817e764584a465e6749d14ca2b608673280cb87bafb4e7dde
     ? ./default.dhall

--- a/kubernetes/cert-manager/IssuerSpec/Type.dhall
+++ b/kubernetes/cert-manager/IssuerSpec/Type.dhall
@@ -3,7 +3,7 @@ let JSON =
       ? https://prelude.dhall-lang.org/v12.0.0/JSON/Type
 
 in  < SelfSigned :
-          ../SelfSignedIssuerSpec/Type.dhall sha256:04e17c1b9afed948af309b5b030f3981ef6b6a1a4f8235bec78a11c101678147
+          ../SelfSignedIssuerSpec/Type.dhall sha256:faa1246bbc6e81cce1042d862b326a8ae70fe1e41884479c5af197197d884efc
         ? ../SelfSignedIssuerSpec/Type.dhall
     | CA :
           ../CAIssuerSpec/Type.dhall sha256:cb8460d3520b283d4ecbe42cafaac81a6b9f99cf7019590adc26411799f7b156

--- a/kubernetes/cert-manager/IssuerSpec/Type.dhall
+++ b/kubernetes/cert-manager/IssuerSpec/Type.dhall
@@ -2,9 +2,7 @@ let JSON =
         https://prelude.dhall-lang.org/v12.0.0/JSON/Type sha256:5adb234f5868a5b0eddeb034d690aaba8cb94ea20d0d557003e90334fff6be3e
       ? https://prelude.dhall-lang.org/v12.0.0/JSON/Type
 
-in  < SelfSigned :
-          ../SelfSignedIssuerSpec/Type.dhall sha256:faa1246bbc6e81cce1042d862b326a8ae70fe1e41884479c5af197197d884efc
-        ? ../SelfSignedIssuerSpec/Type.dhall
+in  < SelfSigned : ../SelfSignedIssuerSpec/Type.dhall
     | CA :
           ../CAIssuerSpec/Type.dhall sha256:cb8460d3520b283d4ecbe42cafaac81a6b9f99cf7019590adc26411799f7b156
         ? ../CAIssuerSpec/Type.dhall

--- a/kubernetes/cert-manager/IssuerSpec/Type.dhall
+++ b/kubernetes/cert-manager/IssuerSpec/Type.dhall
@@ -2,7 +2,9 @@ let JSON =
         https://prelude.dhall-lang.org/v12.0.0/JSON/Type sha256:5adb234f5868a5b0eddeb034d690aaba8cb94ea20d0d557003e90334fff6be3e
       ? https://prelude.dhall-lang.org/v12.0.0/JSON/Type
 
-in  < SelfSigned : ../SelfSignedIssuerSpec/Type.dhall
+in  < SelfSigned :
+          ../SelfSignedIssuerSpec/Type.dhall sha256:faa1246bbc6e81cce1042d862b326a8ae70fe1e41884479c5af197197d884efc
+        ? ../SelfSignedIssuerSpec/Type.dhall
     | CA :
           ../CAIssuerSpec/Type.dhall sha256:cb8460d3520b283d4ecbe42cafaac81a6b9f99cf7019590adc26411799f7b156
         ? ../CAIssuerSpec/Type.dhall

--- a/kubernetes/cert-manager/SelfSignedIssuerSpec/Type.dhall
+++ b/kubernetes/cert-manager/SelfSignedIssuerSpec/Type.dhall
@@ -1,1 +1,5 @@
-{ selfSigned : {} }
+let JSON =
+        https://prelude.dhall-lang.org/v12.0.0/JSON/Type sha256:5adb234f5868a5b0eddeb034d690aaba8cb94ea20d0d557003e90334fff6be3e
+      ? https://prelude.dhall-lang.org/v12.0.0/JSON/Type
+
+in  { selfSigned : JSON }

--- a/kubernetes/cert-manager/SelfSignedIssuerSpec/default.dhall
+++ b/kubernetes/cert-manager/SelfSignedIssuerSpec/default.dhall
@@ -1,1 +1,8 @@
-{ selfSigned = {=} }
+let JSON =
+        https://prelude.dhall-lang.org/v12.0.0/JSON/package.dhall sha256:843783d29e60b558c2de431ce1206ce34bdfde375fcf06de8ec5bf77092fdef7
+      ? https://prelude.dhall-lang.org/v12.0.0/JSON/package.dhall
+
+in  JSON.object
+      ( toMap
+          { selfSigned = JSON.object (toMap { ignoredField = JSON.string "" }) }
+      )

--- a/kubernetes/cert-manager/SelfSignedIssuerSpec/default.dhall
+++ b/kubernetes/cert-manager/SelfSignedIssuerSpec/default.dhall
@@ -2,7 +2,4 @@ let JSON =
         https://prelude.dhall-lang.org/v12.0.0/JSON/package.dhall sha256:843783d29e60b558c2de431ce1206ce34bdfde375fcf06de8ec5bf77092fdef7
       ? https://prelude.dhall-lang.org/v12.0.0/JSON/package.dhall
 
-in  JSON.object
-      ( toMap
-          { selfSigned = JSON.object (toMap { ignoredField = JSON.string "" }) }
-      )
+in  { selfSigned = JSON.object (toMap { ignoredField = JSON.string "" }) }

--- a/kubernetes/cert-manager/SelfSignedIssuerSpec/package.dhall
+++ b/kubernetes/cert-manager/SelfSignedIssuerSpec/package.dhall
@@ -1,5 +1,7 @@
 { Type =
       ./Type.dhall sha256:faa1246bbc6e81cce1042d862b326a8ae70fe1e41884479c5af197197d884efc
     ? ./Type.dhall
-, default = ./default.dhall
+, default =
+      ./default.dhall sha256:54664550b0ca82b148b354232efa7ea5d20b55147af7654c55bf0885789fce88
+    ? ./default.dhall
 }

--- a/kubernetes/cert-manager/SelfSignedIssuerSpec/package.dhall
+++ b/kubernetes/cert-manager/SelfSignedIssuerSpec/package.dhall
@@ -1,7 +1,5 @@
 { Type =
       ./Type.dhall sha256:faa1246bbc6e81cce1042d862b326a8ae70fe1e41884479c5af197197d884efc
     ? ./Type.dhall
-, default =
-      ./default.dhall sha256:7ba80321027b7ab69740702a48cc1da587fe24426ac440a4aaa5580bd1afb9c0
-    ? ./default.dhall
+, default = ./default.dhall
 }

--- a/kubernetes/cert-manager/SelfSignedIssuerSpec/package.dhall
+++ b/kubernetes/cert-manager/SelfSignedIssuerSpec/package.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./Type.dhall sha256:04e17c1b9afed948af309b5b030f3981ef6b6a1a4f8235bec78a11c101678147
+      ./Type.dhall sha256:faa1246bbc6e81cce1042d862b326a8ae70fe1e41884479c5af197197d884efc
     ? ./Type.dhall
 , default =
-      ./default.dhall sha256:d64aeb5fd0a2c8fdfc5bb9d05c18a1d2314dcbb74a1c0c2640c02bb83957f542
+      ./default.dhall sha256:7ba80321027b7ab69740702a48cc1da587fe24426ac440a4aaa5580bd1afb9c0
     ? ./default.dhall
 }

--- a/kubernetes/cert-manager/TypesUnion.dhall
+++ b/kubernetes/cert-manager/TypesUnion.dhall
@@ -2,9 +2,9 @@
       ./Certificate/Type.dhall sha256:3bf3361e68157f65b6a56083bceb4761ef16fd1cbbf6de069bfd7fbf2f373f14
     ? ./Certificate/Type.dhall
 | ClusterIssuer :
-      ./ClusterIssuer/Type.dhall sha256:394d803fd1686a7c72d97bdeb1d65c05e28f84ae8d34c7558890a93ae579d25e
+      ./ClusterIssuer/Type.dhall sha256:555218cba77ee86d2e2d04b9517da72a44cef92f8bd1b11d307829f2d57f9618
     ? ./ClusterIssuer/Type.dhall
 | Issuer :
-      ./Issuer/Type.dhall sha256:394d803fd1686a7c72d97bdeb1d65c05e28f84ae8d34c7558890a93ae579d25e
+      ./Issuer/Type.dhall sha256:555218cba77ee86d2e2d04b9517da72a44cef92f8bd1b11d307829f2d57f9618
     ? ./Issuer/Type.dhall
 >

--- a/kubernetes/cert-manager/package.dhall
+++ b/kubernetes/cert-manager/package.dhall
@@ -5,16 +5,16 @@
       ./CertificateSpec/package.dhall sha256:c01223f2c58aae8b548261c464001cf1506eb8101405b7aa801980a3d0690bfe
     ? ./CertificateSpec/package.dhall
 , ClusterIssuer =
-      ./ClusterIssuer/package.dhall sha256:203a779178af207c6e9a9210bf36ca76b99b26e561960ed3bb7ef1a156c55ac1
+      ./ClusterIssuer/package.dhall sha256:2068d4ad4ddaa5cd254b167f54f754b551a1bbc9dfa9fa012cb45669d6c2bb31
     ? ./ClusterIssuer/package.dhall
 , Issuer =
-      ./Issuer/package.dhall sha256:ac4514877a232d61680a43810d04d7427cbb44c6ad4e168b653d6c27945985ce
+      ./Issuer/package.dhall sha256:acb1f6559f849d6392f1fdb17a9496cf80b2b9f93d3fd7b6f5d0f0222ae454ba
     ? ./Issuer/package.dhall
 , IssuerSpec =
-      ./IssuerSpec/Type.dhall sha256:b81456f409531fce51beff9dd60ff6b8d1de8227e9bc5077fe7e8061707624ff
+      ./IssuerSpec/Type.dhall sha256:a444f78e67974acf5936a24860a1913872122003e42732c6c84391f00dc7d2df
     ? ./IssuerSpec/Type.dhall
 , SelfSignedIssuerSpec =
-      ./SelfSignedIssuerSpec/package.dhall sha256:2a6135a90505e8060c566ab174d9c6e5b28048777b945093bcaeaa4ff277c03c
+      ./SelfSignedIssuerSpec/package.dhall sha256:de50917a6f34016d4661b295997d6b67b12654894b01f8c5da5dd0d2b740787d
     ? ./SelfSignedIssuerSpec/package.dhall
 , CAIssuerSpec =
       ./CAIssuerSpec/package.dhall sha256:7648f583fe9765effdb9f80ce73ad8d2d97b4014b7f1bb4caaa91c06e812c79a

--- a/kubernetes/cert-manager/package.dhall
+++ b/kubernetes/cert-manager/package.dhall
@@ -4,14 +4,22 @@
 , CertificateSpec =
       ./CertificateSpec/package.dhall sha256:c01223f2c58aae8b548261c464001cf1506eb8101405b7aa801980a3d0690bfe
     ? ./CertificateSpec/package.dhall
-, ClusterIssuer = ./ClusterIssuer/package.dhall
-, Issuer = ./Issuer/package.dhall
-, IssuerSpec = ./IssuerSpec/Type.dhall
-, SelfSignedIssuerSpec = ./SelfSignedIssuerSpec/package.dhall
+, ClusterIssuer =
+      ./ClusterIssuer/package.dhall sha256:2068d4ad4ddaa5cd254b167f54f754b551a1bbc9dfa9fa012cb45669d6c2bb31
+    ? ./ClusterIssuer/package.dhall
+, Issuer =
+      ./Issuer/package.dhall sha256:acb1f6559f849d6392f1fdb17a9496cf80b2b9f93d3fd7b6f5d0f0222ae454ba
+    ? ./Issuer/package.dhall
+, IssuerSpec =
+      ./IssuerSpec/Type.dhall sha256:a444f78e67974acf5936a24860a1913872122003e42732c6c84391f00dc7d2df
+    ? ./IssuerSpec/Type.dhall
+, SelfSignedIssuerSpec =
+      ./SelfSignedIssuerSpec/package.dhall sha256:51acd784f92d79563c16203dac3c0f3443597d8aecfff3347eb0c149b7508474
+    ? ./SelfSignedIssuerSpec/package.dhall
 , CAIssuerSpec =
       ./CAIssuerSpec/package.dhall sha256:7648f583fe9765effdb9f80ce73ad8d2d97b4014b7f1bb4caaa91c06e812c79a
     ? ./CAIssuerSpec/package.dhall
 , TypesUnion =
-      ./TypesUnion.dhall sha256:3fb2f9f9687f3df5ac205a53962b511705a6f21b231429464d4eec788e41c35b
+      ./TypesUnion.dhall sha256:719dba5218248cf7c3cd3a82d1f7772b272df5d4f92973b05adda13d8b7165a5
     ? ./TypesUnion.dhall
 }

--- a/kubernetes/cert-manager/package.dhall
+++ b/kubernetes/cert-manager/package.dhall
@@ -4,18 +4,10 @@
 , CertificateSpec =
       ./CertificateSpec/package.dhall sha256:c01223f2c58aae8b548261c464001cf1506eb8101405b7aa801980a3d0690bfe
     ? ./CertificateSpec/package.dhall
-, ClusterIssuer =
-      ./ClusterIssuer/package.dhall sha256:2068d4ad4ddaa5cd254b167f54f754b551a1bbc9dfa9fa012cb45669d6c2bb31
-    ? ./ClusterIssuer/package.dhall
-, Issuer =
-      ./Issuer/package.dhall sha256:acb1f6559f849d6392f1fdb17a9496cf80b2b9f93d3fd7b6f5d0f0222ae454ba
-    ? ./Issuer/package.dhall
-, IssuerSpec =
-      ./IssuerSpec/Type.dhall sha256:a444f78e67974acf5936a24860a1913872122003e42732c6c84391f00dc7d2df
-    ? ./IssuerSpec/Type.dhall
-, SelfSignedIssuerSpec =
-      ./SelfSignedIssuerSpec/package.dhall sha256:de50917a6f34016d4661b295997d6b67b12654894b01f8c5da5dd0d2b740787d
-    ? ./SelfSignedIssuerSpec/package.dhall
+, ClusterIssuer = ./ClusterIssuer/package.dhall
+, Issuer = ./Issuer/package.dhall
+, IssuerSpec = ./IssuerSpec/Type.dhall
+, SelfSignedIssuerSpec = ./SelfSignedIssuerSpec/package.dhall
 , CAIssuerSpec =
       ./CAIssuerSpec/package.dhall sha256:7648f583fe9765effdb9f80ce73ad8d2d97b4014b7f1bb4caaa91c06e812c79a
     ? ./CAIssuerSpec/package.dhall

--- a/kubernetes/package.dhall
+++ b/kubernetes/package.dhall
@@ -1,5 +1,5 @@
 { cert-manager =
-      ./cert-manager/package.dhall sha256:279048afecaf81c04e4de534068e5bfe2df383b4cba9dcd0bb4e4ef90c66c6df
+      ./cert-manager/package.dhall sha256:5f4f4a9b07e8505661ebef051183b2a76851230afe25d141185f58d7eae60d40
     ? ./cert-manager/package.dhall
 , kubernetes-external-secrets =
       ./kubernetes-external-secrets/package.dhall sha256:4b52e6019a04f34da8819d85e6f43d5387040fbab102ba88399584fd0b845ee6

--- a/kubernetes/package.dhall
+++ b/kubernetes/package.dhall
@@ -1,5 +1,5 @@
 { cert-manager =
-      ./cert-manager/package.dhall sha256:5f4f4a9b07e8505661ebef051183b2a76851230afe25d141185f58d7eae60d40
+      ./cert-manager/package.dhall sha256:358cd3c13b209a06c10be8edfb599a86464fc1769e16afffd00a6589ffcc641a
     ? ./cert-manager/package.dhall
 , kubernetes-external-secrets =
       ./kubernetes-external-secrets/package.dhall sha256:4b52e6019a04f34da8819d85e6f43d5387040fbab102ba88399584fd0b845ee6

--- a/package.dhall
+++ b/package.dhall
@@ -1,5 +1,5 @@
 { kubernetes =
-      ./kubernetes/package.dhall sha256:1b8d8b2f645473dafb8ae24da18818843531c37cbd7f9ac9c2f95943134e9bcb
+      ./kubernetes/package.dhall sha256:cef9c573efe44c020b7b8872c1fb8cfa66b0f03d3963a686cc050dc42fb81b27
     ? ./kubernetes/package.dhall
 , Prelude =
       https://prelude.dhall-lang.org/v12.0.0/package.dhall sha256:aea6817682359ae1939f3a15926b84ad5763c24a3740103202d2eaaea4d01f4c

--- a/package.dhall
+++ b/package.dhall
@@ -1,5 +1,5 @@
 { kubernetes =
-      ./kubernetes/package.dhall sha256:cef9c573efe44c020b7b8872c1fb8cfa66b0f03d3963a686cc050dc42fb81b27
+      ./kubernetes/package.dhall sha256:04f02a9263a715749a0b479e241869dc8f0f5616585a558ee8f4928347dd1133
     ? ./kubernetes/package.dhall
 , Prelude =
       https://prelude.dhall-lang.org/v12.0.0/package.dhall sha256:aea6817682359ae1939f3a15926b84ad5763c24a3740103202d2eaaea4d01f4c


### PR DESCRIPTION
Because `dhall-to-yaml --omit-empty` removes entire empty objects, but some kubernetes objects need to be there, we need to insert a dummy value