### PR TITLE
Fix versioning inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ let packages = https://raw.githubusercontent.com/EarnestResearch/dhall-packages/
 
 let argocd = packages.kubernetes.argocd
 
-let k8s = packages.kubernetes.k8s.schemas
+let k8s = packages.kubernetes.k8s.`1-14`
 
 in  argocd.Application::{
     , metadata = k8s.ObjectMeta::{ name = "hello-app" }
@@ -62,7 +62,7 @@ If you don't want to download the entire packages collection, you can simply ref
 
 Note: if you use this repository for kubernetes and you are converting to YAML, you should run
 ```sh
-dhall-to-yaml --omitEmpty
+dhall-to-yaml --omit-empty
 ```
 
 ## Binary cache

--- a/kubernetes/argocd/Project/Type.dhall
+++ b/kubernetes/argocd/Project/Type.dhall
@@ -1,9 +1,10 @@
 let k8s =
-      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/4ad58156b7fdbbb6da0543d8b314df899feca077/types.dhall sha256:e48e21b807dad217a6c3e631fcaf3e950062310bfb4a8bbcecc330eb7b2f60ed
+        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+      ? ../../k8s/1.14.dhall
 
 in  { apiVersion : Text
     , kind : Text
-    , metadata : k8s.ObjectMeta
+    , metadata : k8s.ObjectMeta.Type
     , spec :
           ../ProjectSpec/Type.dhall sha256:290e51c402f3e27ca91228375ce3462cf55b0e8bc395ec6813c3d6137eabdd29
         ? ../ProjectSpec/Type.dhall

--- a/kubernetes/k8s/1.17.dhall
+++ b/kubernetes/k8s/1.17.dhall
@@ -1,2 +1,2 @@
-  https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.14/package.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-? https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.14/package.dhall
+  https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.17/package.dhall sha256:e9c55c7ff71f901314129e7ef100c3af5ec7a918dce25e06d83fa8c5472cb680
+? https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.17/package.dhall

--- a/kubernetes/k8s/package.dhall
+++ b/kubernetes/k8s/package.dhall
@@ -8,6 +8,6 @@
       ./1.16.dhall sha256:ab1c971ddeb178c1cfc5e749b211b4fe6fdb6fa1b68b10de62aeb543efcd60b3
     ? ./1.16.dhall
 , `1-17` =
-      ./1.17.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+      ./1.17.dhall sha256:e9c55c7ff71f901314129e7ef100c3af5ec7a918dce25e06d83fa8c5472cb680
     ? ./1.17.dhall
 }

--- a/kubernetes/package.dhall
+++ b/kubernetes/package.dhall
@@ -5,7 +5,7 @@
       ./kubernetes-external-secrets/package.dhall sha256:4b52e6019a04f34da8819d85e6f43d5387040fbab102ba88399584fd0b845ee6
     ? ./kubernetes-external-secrets/package.dhall
 , k8s =
-      ./k8s/package.dhall sha256:4b575d18387671adf3e3b1db4fe7fa6ff880c26c8c69082176b4ef84dee2e4d6
+      ./k8s/package.dhall sha256:d6d918b7558b4ae5c3774c9a2a460ade08008dd0f458770d8fd81efa0d588aff
     ? ./k8s/package.dhall
 , argocd =
       ./argocd/package.dhall sha256:37659a96e878f98fa6643ec2db53c17dfc9cc388c3a445a979e0310be12e6611

--- a/package.dhall
+++ b/package.dhall
@@ -1,5 +1,5 @@
 { kubernetes =
-      ./kubernetes/package.dhall sha256:a1c73064a7d365a5be1eba39c7d2ca882ab9d1fa53f38c3aa10ecb9067fa1131
+      ./kubernetes/package.dhall sha256:9612994f4c633ab868b4c2382da64904f77a287f2f5e88d044a60d16266bfbc8
     ? ./kubernetes/package.dhall
 , Prelude =
       https://prelude.dhall-lang.org/v12.0.0/package.dhall sha256:aea6817682359ae1939f3a15926b84ad5763c24a3740103202d2eaaea4d01f4c


### PR DESCRIPTION
* Fix k8s/1.17.dhall reference to upstream 1.14

* Fix README example to point to 1.14 (see #53)

* Fix argocd/Project/Type.dhall pointing to different commit