### PR TITLE
K8s 1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The idea is to facilitate package discovery and provide versions containing pack
 This repository maps to version [12.0.0](https://github.com/dhall-lang/dhall-lang/releases/tag/v12.0.0) of the dhall standard, and therefore requires dhall [1.28.0](https://github.com/dhall-lang/dhall-haskell/releases/tag/1.28.0) or later.
 
 ## What does this repository contain?
-- [kubernetes](kubernetes) Various bindings for Kubernetes, based on [dhall-kubernetes](https://github.com/dhall-lang/dhall-kubernetes)
+- [kubernetes](kubernetes) Various bindings for Kubernetes, based on [dhall-kubernetes](https://github.com/dhall-lang/dhall-kubernetes). The base kubernetes version this repository uses is `1.15`.
     - [argocd](kubernetes/argocd) Manually curated bindings for ArgoCD. Updated to version 1.2.1
     - [cert-manager](kubernetes/cert-manager) Some bindings for cert-manager. Contributions welcome!
     - [k8s](kubernetes/k8s) Re-export of [dhall-kubernetes](https://github.com/dhall-lang/dhall-kubernetes) for convenience
@@ -21,6 +21,7 @@ This repository maps to version [12.0.0](https://github.com/dhall-lang/dhall-lan
     - [webhook](kubernetes/webhook). Opinionated template to create admission webhooks on Kubernetes
 - [util](util/CronTab) Various utilities and types that can be shared
     - [CronTab](util/CronTab) CronTab type, default and "show" function.
+
 
 ## How to use this repository
 You can import all the packages by doing (it's better if you freeze the import and point it to a specific commit):

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ let packages = https://raw.githubusercontent.com/EarnestResearch/dhall-packages/
 
 let argocd = packages.kubernetes.argocd
 
-let k8s = packages.kubernetes.k8s.`1-14`
+let k8s = packages.kubernetes.k8s.`1-15`
 
 in  argocd.Application::{
     , metadata = k8s.ObjectMeta::{ name = "hello-app" }

--- a/kubernetes/ambassador/AuthService/Type.dhall
+++ b/kubernetes/ambassador/AuthService/Type.dhall
@@ -4,8 +4,8 @@
 -}
 
 let k8s =
-        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../../k8s/1.14.dhall
+        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../../k8s/1.15.dhall
 
 in  { apiVersion : Text
     , kind : Text

--- a/kubernetes/ambassador/AuthService/package.dhall
+++ b/kubernetes/ambassador/AuthService/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:fd1a70a84023f29f98bb225902be3442d92302a9205a1ffc9b913c03d8b60a03
+      ./Type.dhall sha256:bbcc9506087f49de445a2fe0f2279a9b48995e1f6ee7f362bb15349e9ff30cec
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:1ba6e19e9efe37479e887485fd948f45ab988a42ef1edb4a393d8b22ba2eca87

--- a/kubernetes/ambassador/Mapping/Type.dhall
+++ b/kubernetes/ambassador/Mapping/Type.dhall
@@ -5,8 +5,8 @@
 -}
 
 let k8s =
-        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../../k8s/1.14.dhall
+        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../../k8s/1.15.dhall
 
 in  { apiVersion : Text
     , kind : Text

--- a/kubernetes/ambassador/Mapping/package.dhall
+++ b/kubernetes/ambassador/Mapping/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:fdc0f198ffb2e46a5605105e0a42a4cb30b09f480e80f1eda0f159b41b273dcc
+      ./Type.dhall sha256:f0b44d9a4d1407a40907791ab320ced86700ca5e624a6286337db8fc66adbbc8
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:77840fc95c95f5c8ac7d5c7f8a8b64615a3930e4de6e337199951a19324f13ba

--- a/kubernetes/ambassador/MappingV2/Type.dhall
+++ b/kubernetes/ambassador/MappingV2/Type.dhall
@@ -5,8 +5,8 @@
 -}
 
 let k8s =
-        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../../k8s/1.14.dhall
+        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../../k8s/1.15.dhall
 
 in  { apiVersion : Text
     , kind : Text

--- a/kubernetes/ambassador/MappingV2/package.dhall
+++ b/kubernetes/ambassador/MappingV2/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:37612b234eee4d02c7b51c7894db1fd05a9371555574f917bc3c83c88ba7d9cb
+      ./Type.dhall sha256:901418bbef3218f155d30ac98792797437ea5b0a3dc7509210416444279f810c
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:7e2ca7f1d4a89b214af43ec5144f12cb597923968d814f4489462b4d069d2b67

--- a/kubernetes/ambassador/Readme.md
+++ b/kubernetes/ambassador/Readme.md
@@ -10,7 +10,7 @@ let ambassador =
       https://raw.githubusercontent.com/EarnestResearch/dhall-packages/kubernetes/ambassador/package.dhall
 
 let k8s =
-      https://raw.githubusercontent.com/EarnestResearch/dhall-packages/master/kubernetes/k8s/1.14.dhall
+      https://raw.githubusercontent.com/EarnestResearch/dhall-packages/master/kubernetes/k8s/1.15.dhall
 
 in  ambassador.Mapping::{
     , metadata = k8s.ObjectMeta::{ name = "guestbook" }
@@ -26,7 +26,7 @@ You can leverage dhall's capabilities and tie the mapping to the service definit
 
 ```dhall
 let k8s =
-      https://raw.githubusercontent.com/EarnestResearch/dhall-packages/master/kubernetes/k8s/1.14.dhall
+      https://raw.githubusercontent.com/EarnestResearch/dhall-packages/master/kubernetes/k8s/1.15.dhall
 
 let ambassador =
       https://raw.githubusercontent.com/EarnestResearch/dhall-packages/master/kubernetes/ambassador/package.dhall

--- a/kubernetes/ambassador/package.dhall
+++ b/kubernetes/ambassador/package.dhall
@@ -1,5 +1,5 @@
 { AuthService =
-      ./AuthService/package.dhall sha256:38aba5d9403f93dfc41da40bc78950872a8ec03c60b37fb903a110506094be79
+      ./AuthService/package.dhall sha256:8fb6a35ad2a44bc06507623ab50d2b331d39fe20503bf9c5aceba6b410edb042
     ? ./AuthService/package.dhall
 , AuthServiceIncludeBody =
       ./AuthServiceIncludeBody/package.dhall sha256:4f65364e68fd4e6059f72a338fc50c92c519839c6e9f452dbc0befdc46e0b75f
@@ -32,13 +32,13 @@
       ./LoadbalancerPolicy/package.dhall sha256:4745eec474d5fee647461c62cc5ad690860f16dfa5a9cf19b6763d127ec72c0c
     ? ./LoadbalancerPolicy/package.dhall
 , Mapping =
-      ./Mapping/package.dhall sha256:b47cea9243f5ff7ab90e7dcdd8b2822cecf0a39f12cd079ac37c1e6039451510
+      ./Mapping/package.dhall sha256:b732ca4ef26ef3cbfbb6d8aead811f98bf51c2d74aee5e13ade657b2da9fe2b5
     ? ./Mapping/package.dhall
 , MappingSpec =
       ./MappingSpec/package.dhall sha256:ac43b68bd088657681858fe761529135357019bfb55faa09cedf85a0df3780ae
     ? ./MappingSpec/package.dhall
 , MappingV2 =
-      ./MappingV2/package.dhall sha256:11efd70c6d3de56593ba26837b7927b09fd29b915330e2160daff8a05a2cfc4a
+      ./MappingV2/package.dhall sha256:63e86cddb5a960bdcd85d9db515ec37dea6f591a68881f9143e0c4ce8faad92c
     ? ./MappingV2/package.dhall
 , MappingSpecV2 =
       ./MappingSpecV2/package.dhall sha256:fa039d5cf9e82d6b869f50b59db25ac319e4930b6ace9ad8160418de92639415

--- a/kubernetes/argo/defaults.dhall
+++ b/kubernetes/argo/defaults.dhall
@@ -71,7 +71,7 @@
       ./defaults/io.argoproj.workflow.v1alpha1.S3Bucket.dhall sha256:b2386ff0eb06a6a3b37e4b3337f238d7593232137697f4057784d04203088ff5
     ? ./defaults/io.argoproj.workflow.v1alpha1.S3Bucket.dhall
 , ScriptTemplate =
-      ./defaults/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:6a83d6c43bfc0f8a75a44dc3df8147e8bd0550141a4b7dd0ddd98c6692615fb9
+      ./defaults/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:2915a675aa3c6294f5788827a54046076756a34f9fc31e9527c9c89ea18cf7cf
     ? ./defaults/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
 , Sequence =
       ./defaults/io.argoproj.workflow.v1alpha1.Sequence.dhall sha256:e89c73327f41a482a14b764fd3cb1b922f3c28d48967c6f146126b27660b371a
@@ -83,22 +83,22 @@
       ./defaults/io.argoproj.workflow.v1alpha1.TarStrategy.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
     ? ./defaults/io.argoproj.workflow.v1alpha1.TarStrategy.dhall
 , Template =
-      ./defaults/io.argoproj.workflow.v1alpha1.Template.dhall sha256:435f01c8749d90c90c6ebe7ea26272d79c10aef5a03659d5062646bcdc307c44
+      ./defaults/io.argoproj.workflow.v1alpha1.Template.dhall sha256:73aaaec5b0806d5548f46bdc0cbca39e5db5adc664f47a05dda512790c64d478
     ? ./defaults/io.argoproj.workflow.v1alpha1.Template.dhall
 , UserContainer =
-      ./defaults/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:15e48cd5c79040fe0e2ee0b5314f2eb4edad9b228d3dfdb44cf71fb9a0ba888d
+      ./defaults/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:78f1b767410ba41e0e2c5bab41d12b4ca6141566aa2c3dd8b2e3209279490b38
     ? ./defaults/io.argoproj.workflow.v1alpha1.UserContainer.dhall
 , ValueFrom =
       ./defaults/io.argoproj.workflow.v1alpha1.ValueFrom.dhall sha256:555180487c64ec519a9edfab1ecbf4a9ace197e6b781029b2fad639658ec0bd6
     ? ./defaults/io.argoproj.workflow.v1alpha1.ValueFrom.dhall
 , Workflow =
-      ./defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:f4b4f3353829b867084128b99c102bbeb5a2b621fd9a106ba84b2b3f0c2505ea
+      ./defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:9ade383df4196cbc43f433c3388042614188017b75dbbbccb405aa0f5fa156e5
     ? ./defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall
 , WorkflowList =
-      ./defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:22da1e7f5446e52ce5812d311ee47c0aa9580834353eb88342c3577e7fce0609
+      ./defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:af32d1ed1d44b3e9809532b05952fa1003699b90d1fbe790d4c3c010f627926b
     ? ./defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
 , WorkflowSpec =
-      ./defaults/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:23fed14b3cc7b68662d60c24fae28a2d60b5333a25eb66bb3d62d56090ffccfd
+      ./defaults/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:73e721a84f0a1be7f8adee32e02becdde3f64162051ba0fa059f2a364743c2dd
     ? ./defaults/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
 , WorkflowStep =
       ./defaults/io.argoproj.workflow.v1alpha1.WorkflowStep.dhall sha256:90232b03be7ef9b230b94a5310d514a48c33397668e8a9a963a75270b4342f78

--- a/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
+++ b/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
@@ -49,7 +49,7 @@
       )
 , securityContext =
     None
-      (   ./../types/io.k8s.api.core.v1.SecurityContext.dhall sha256:2af8194b7c332726b1a90fc36a47aa20f507fedf14e2e238e72153c0e0979798
+      (   ./../types/io.k8s.api.core.v1.SecurityContext.dhall sha256:ae334ad99dfb4d0d69fd0826eab7af27147f0713a7eecccf4b99f697488704c8
         ? ./../types/io.k8s.api.core.v1.SecurityContext.dhall
       )
 , stdin = None Bool

--- a/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.Template.dhall
+++ b/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.Template.dhall
@@ -3,7 +3,7 @@
     ? ./io.argoproj.workflow.v1alpha1.ArtifactLocation.dhall
 , initContainers =
     [] : List
-           (   ./../types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:20dee8c8a03b7be85600bf83fa468410ae643f7c48d84d08c7b562ced7630e3a
+           (   ./../types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:da7065231aecb9e3f7a4975ac9d02c33f63f6cae708999f55b195532f90c3a9d
              ? ./../types/io.argoproj.workflow.v1alpha1.UserContainer.dhall
            )
 , metadata =
@@ -15,7 +15,7 @@
     ? ./io.argoproj.workflow.v1alpha1.RetryStrategy.dhall
 , sidecars =
     [] : List
-           (   ./../types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:20dee8c8a03b7be85600bf83fa468410ae643f7c48d84d08c7b562ced7630e3a
+           (   ./../types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:da7065231aecb9e3f7a4975ac9d02c33f63f6cae708999f55b195532f90c3a9d
              ? ./../types/io.argoproj.workflow.v1alpha1.UserContainer.dhall
            )
 , steps =
@@ -46,7 +46,7 @@
       )
 , container =
     None
-      (   ./../types/io.k8s.api.core.v1.Container.dhall sha256:db5f4f75cf6cf3888c0f7a70deef4493921255eb21bb02098660383d4927051d
+      (   ./../types/io.k8s.api.core.v1.Container.dhall sha256:ad60df4905ca468fd5134fe0267bf255facc227bc5e8a505257f2d57567a13f2
         ? ./../types/io.k8s.api.core.v1.Container.dhall
       )
 , daemon = None Bool
@@ -76,7 +76,7 @@
 , schedulerName = None Text
 , script =
     None
-      (   ./../types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:9d26b255c7ef88260efc2415cddde8c69dbefe05c7d59793ec8c82cd6441d551
+      (   ./../types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:a15f3aba6b20bf67bdf62c06c420bd04fca0acbd75a20afce4ac59a0cbc70638
         ? ./../types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
       )
 }

--- a/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.UserContainer.dhall
+++ b/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.UserContainer.dhall
@@ -50,7 +50,7 @@
       )
 , securityContext =
     None
-      (   ./../types/io.k8s.api.core.v1.SecurityContext.dhall sha256:2af8194b7c332726b1a90fc36a47aa20f507fedf14e2e238e72153c0e0979798
+      (   ./../types/io.k8s.api.core.v1.SecurityContext.dhall sha256:ae334ad99dfb4d0d69fd0826eab7af27147f0713a7eecccf4b99f697488704c8
         ? ./../types/io.k8s.api.core.v1.SecurityContext.dhall
       )
 , stdin = None Bool

--- a/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall
+++ b/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall
@@ -1,6 +1,6 @@
 { apiVersion = "argoproj.io/v1alpha1"
 , kind = "Workflow"
 , spec =
-      ./io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:23fed14b3cc7b68662d60c24fae28a2d60b5333a25eb66bb3d62d56090ffccfd
+      ./io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:73e721a84f0a1be7f8adee32e02becdde3f64162051ba0fa059f2a364743c2dd
     ? ./io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
 }

--- a/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
+++ b/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
@@ -2,7 +2,7 @@
 , kind = "WorkflowList"
 , items =
     [] : List
-           (   ./../types/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:f3a816e0be2f93d473718234a7a513f7c98d04545a27c2d23c95fceefa7fce86
+           (   ./../types/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:951176b8e0f053e4bf461118aed05464c70809ac4acaf930e6803df79a809445
              ? ./../types/io.argoproj.workflow.v1alpha1.Workflow.dhall
            )
 }

--- a/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
+++ b/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
@@ -6,7 +6,7 @@
 , nodeSelector = [] : List { mapKey : Text, mapValue : Text }
 , templates =
     [] : List
-           (   ./../types/io.argoproj.workflow.v1alpha1.Template.dhall sha256:331df1402df98f077c72cd7a40580f5369ca3617d9a499ea92c1d1fe99ed5092
+           (   ./../types/io.argoproj.workflow.v1alpha1.Template.dhall sha256:2119e0d70f4120a310eeef38294b05fd507db6961e357c805752c2214942b48c
              ? ./../types/io.argoproj.workflow.v1alpha1.Template.dhall
            )
 , tolerations =
@@ -16,7 +16,7 @@
            )
 , volumeClaimTemplates =
     [] : List
-           (   ./../types/io.k8s.api.core.v1.PersistentVolumeClaim.dhall sha256:bb3a244115c928544d8287f9fbce5080ac837832b6f08dccebbda7eb5d29e843
+           (   ./../types/io.k8s.api.core.v1.PersistentVolumeClaim.dhall sha256:e26ba9b031f0ec56b4bf4f3b307157797845837ce920bd901fb9c3980a747f39
              ? ./../types/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
            )
 , volumes =

--- a/kubernetes/argo/package.dhall
+++ b/kubernetes/argo/package.dhall
@@ -1,13 +1,13 @@
 { defaults =
-      ./defaults.dhall sha256:2319d102500bd719675f8151b4e84b12e488651d8c07fd9b888ab3a800c4f41d
+      ./defaults.dhall sha256:db5dad4c38eae6210abd45a29924498e732a67af18e219fa68da60282561c4ec
     ? ./defaults.dhall
 , types =
-      ./types.dhall sha256:ab35786728384eacc1df2a359135ccfc6c141076b664df4a11c771bff39ec15f
+      ./types.dhall sha256:1c1c80538951a0ea39a505518546a6b0919e3ec7eef266884bcf0108ee1409fe
     ? ./types.dhall
 , typesUnion =
-      ./typesUnion.dhall sha256:33e9a9d619f6b202ac3cfc6f9a9174987de9272c8e25f1f313c6441612da3611
+      ./typesUnion.dhall sha256:d4f9f480047a3dd3054557e7c01a262c52536f114711fb2811079a1c61a15381
     ? ./typesUnion.dhall
 , schemas =
-      ./schemas.dhall sha256:0b2f1fd43591a5f4df3156179f601fbea9adc86c740becf5629570bf82a8874e
+      ./schemas.dhall sha256:740e3d6befffa1dee6961e7b74708ba0360ba4c3dcb79adfa2442b9e6b4ea4f9
     ? ./schemas.dhall
 }

--- a/kubernetes/argo/schemas.dhall
+++ b/kubernetes/argo/schemas.dhall
@@ -71,7 +71,7 @@
       ./schemas/io.argoproj.workflow.v1alpha1.S3Bucket.dhall sha256:24eb797f2a0b540fbdb1b51f6752d106a8ffa6260bc9b3f7197b0593136ddb67
     ? ./schemas/io.argoproj.workflow.v1alpha1.S3Bucket.dhall
 , ScriptTemplate =
-      ./schemas/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:ca707a79acd3c0b7ddb8fd2b142d55ac89b9c07e642404a7e6cf1e22b582cc96
+      ./schemas/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:c3010e987e4b79f662721b9e501c9da045c23d30e4b7512ecc87947032ea600e
     ? ./schemas/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
 , Sequence =
       ./schemas/io.argoproj.workflow.v1alpha1.Sequence.dhall sha256:07c2d774d97909464b28ebb352b6ae2b3ce487dba17b7db094b53d7e08e1b929
@@ -83,22 +83,22 @@
       ./schemas/io.argoproj.workflow.v1alpha1.TarStrategy.dhall sha256:81a1bf11fb9dc588941bd83400ed571298585a700a53e858456806f7ea3b8ce2
     ? ./schemas/io.argoproj.workflow.v1alpha1.TarStrategy.dhall
 , Template =
-      ./schemas/io.argoproj.workflow.v1alpha1.Template.dhall sha256:f91820a1d6b583bff3dff06d39215b373a24d8c3fbe74531e62d4f9a7b5a5990
+      ./schemas/io.argoproj.workflow.v1alpha1.Template.dhall sha256:f119e07b88f37b386b26824df7f34ae452450261d1446ad8fb8f03a225e5f4fc
     ? ./schemas/io.argoproj.workflow.v1alpha1.Template.dhall
 , UserContainer =
-      ./schemas/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:88a9923bd9f2b9b5a45b983a8071b1d0dccab2e9a06f3931c780cab98691a7a7
+      ./schemas/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:fde3d3c6775003a0a6096fa0a1ae9028b833df4eebb0310d7b42ae743e99ba36
     ? ./schemas/io.argoproj.workflow.v1alpha1.UserContainer.dhall
 , ValueFrom =
       ./schemas/io.argoproj.workflow.v1alpha1.ValueFrom.dhall sha256:ae8f89b0fb93156550239aa72d260550c52264946526edb28228d73f5abe8a81
     ? ./schemas/io.argoproj.workflow.v1alpha1.ValueFrom.dhall
 , Workflow =
-      ./schemas/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:1f953af8a904136c19a6edd0a655018650fc723ad5bddf7e623c7c094395a0e9
+      ./schemas/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:9dadcba95364ccf1ea92315b946edb693ce401e1cb17e56b494670db61f25a71
     ? ./schemas/io.argoproj.workflow.v1alpha1.Workflow.dhall
 , WorkflowList =
-      ./schemas/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:ea2e28931cb7ed9d0e88a9483f3007c47ae587364d697ceba406117b9f79bf3d
+      ./schemas/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:ee3cd7478547c88068c6e78e6e9de609412ccb5d396ca91415de698ac56027c4
     ? ./schemas/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
 , WorkflowSpec =
-      ./schemas/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:ac1866d5f2a4c1c297934a3c5a87e3f6e15705cc0d57c086cfc860aca3b1bafb
+      ./schemas/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:fc4d22776efd8bce1af93154f7747659fb77ddc87482626c29cf438edba7c1d9
     ? ./schemas/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
 , WorkflowStep =
       ./schemas/io.argoproj.workflow.v1alpha1.WorkflowStep.dhall sha256:c73c9fe3136b55d2af39a8c57df773e067dfda327d5b217271939bbd58a61746

--- a/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
+++ b/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:9d26b255c7ef88260efc2415cddde8c69dbefe05c7d59793ec8c82cd6441d551
+      ./../types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:a15f3aba6b20bf67bdf62c06c420bd04fca0acbd75a20afce4ac59a0cbc70638
     ? ./../types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
 , default =
-      ./../defaults/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:6a83d6c43bfc0f8a75a44dc3df8147e8bd0550141a4b7dd0ddd98c6692615fb9
+      ./../defaults/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:2915a675aa3c6294f5788827a54046076756a34f9fc31e9527c9c89ea18cf7cf
     ? ./../defaults/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
 }

--- a/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.Template.dhall
+++ b/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.Template.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.workflow.v1alpha1.Template.dhall sha256:331df1402df98f077c72cd7a40580f5369ca3617d9a499ea92c1d1fe99ed5092
+      ./../types/io.argoproj.workflow.v1alpha1.Template.dhall sha256:2119e0d70f4120a310eeef38294b05fd507db6961e357c805752c2214942b48c
     ? ./../types/io.argoproj.workflow.v1alpha1.Template.dhall
 , default =
-      ./../defaults/io.argoproj.workflow.v1alpha1.Template.dhall sha256:435f01c8749d90c90c6ebe7ea26272d79c10aef5a03659d5062646bcdc307c44
+      ./../defaults/io.argoproj.workflow.v1alpha1.Template.dhall sha256:73aaaec5b0806d5548f46bdc0cbca39e5db5adc664f47a05dda512790c64d478
     ? ./../defaults/io.argoproj.workflow.v1alpha1.Template.dhall
 }

--- a/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.UserContainer.dhall
+++ b/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.UserContainer.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:20dee8c8a03b7be85600bf83fa468410ae643f7c48d84d08c7b562ced7630e3a
+      ./../types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:da7065231aecb9e3f7a4975ac9d02c33f63f6cae708999f55b195532f90c3a9d
     ? ./../types/io.argoproj.workflow.v1alpha1.UserContainer.dhall
 , default =
-      ./../defaults/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:15e48cd5c79040fe0e2ee0b5314f2eb4edad9b228d3dfdb44cf71fb9a0ba888d
+      ./../defaults/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:78f1b767410ba41e0e2c5bab41d12b4ca6141566aa2c3dd8b2e3209279490b38
     ? ./../defaults/io.argoproj.workflow.v1alpha1.UserContainer.dhall
 }

--- a/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.Workflow.dhall
+++ b/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.Workflow.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:f3a816e0be2f93d473718234a7a513f7c98d04545a27c2d23c95fceefa7fce86
+      ./../types/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:951176b8e0f053e4bf461118aed05464c70809ac4acaf930e6803df79a809445
     ? ./../types/io.argoproj.workflow.v1alpha1.Workflow.dhall
 , default =
-      ./../defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:f4b4f3353829b867084128b99c102bbeb5a2b621fd9a106ba84b2b3f0c2505ea
+      ./../defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:9ade383df4196cbc43f433c3388042614188017b75dbbbccb405aa0f5fa156e5
     ? ./../defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall
 }

--- a/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
+++ b/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:d129a0637d44d12aa279f98568efa9dd5cda3f4fcdd78090881120a8230f2314
+      ./../types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:706eea3450603dc2f8dd79f7e37a5b0f181175ab23a16a5f18b12ad1441d200d
     ? ./../types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
 , default =
-      ./../defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:22da1e7f5446e52ce5812d311ee47c0aa9580834353eb88342c3577e7fce0609
+      ./../defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:af32d1ed1d44b3e9809532b05952fa1003699b90d1fbe790d4c3c010f627926b
     ? ./../defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
 }

--- a/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
+++ b/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:311e15860d311f6a55ff11cdc9a90d9ce15bf9030aad2e68d0d6cb6793fcda8a
+      ./../types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:2132a175ca4f36ed9caa0ddc0f95d0bceae991ffe8894369741040fa3082ad26
     ? ./../types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
 , default =
-      ./../defaults/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:23fed14b3cc7b68662d60c24fae28a2d60b5333a25eb66bb3d62d56090ffccfd
+      ./../defaults/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:73e721a84f0a1be7f8adee32e02becdde3f64162051ba0fa059f2a364743c2dd
     ? ./../defaults/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
 }

--- a/kubernetes/argo/types.dhall
+++ b/kubernetes/argo/types.dhall
@@ -74,7 +74,7 @@
       ./types/io.argoproj.workflow.v1alpha1.S3Bucket.dhall sha256:c788453a89be48bf09e5b05bfc9af4ae542d4eeebb28018ade3c1cbab55827e7
     ? ./types/io.argoproj.workflow.v1alpha1.S3Bucket.dhall
 , ScriptTemplate =
-      ./types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:9d26b255c7ef88260efc2415cddde8c69dbefe05c7d59793ec8c82cd6441d551
+      ./types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:a15f3aba6b20bf67bdf62c06c420bd04fca0acbd75a20afce4ac59a0cbc70638
     ? ./types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
 , Sequence =
       ./types/io.argoproj.workflow.v1alpha1.Sequence.dhall sha256:e7cfed05c1b1fe58ce672e268aef05f8fb7e75b9ae3da9e21e2a691a76b5f8ae
@@ -86,22 +86,22 @@
       ./types/io.argoproj.workflow.v1alpha1.TarStrategy.dhall sha256:0912602a19e01dcff30f351958d2d9b69519c9be61b57b1b32a2a569bf8bf5f9
     ? ./types/io.argoproj.workflow.v1alpha1.TarStrategy.dhall
 , Template =
-      ./types/io.argoproj.workflow.v1alpha1.Template.dhall sha256:331df1402df98f077c72cd7a40580f5369ca3617d9a499ea92c1d1fe99ed5092
+      ./types/io.argoproj.workflow.v1alpha1.Template.dhall sha256:2119e0d70f4120a310eeef38294b05fd507db6961e357c805752c2214942b48c
     ? ./types/io.argoproj.workflow.v1alpha1.Template.dhall
 , UserContainer =
-      ./types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:20dee8c8a03b7be85600bf83fa468410ae643f7c48d84d08c7b562ced7630e3a
+      ./types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:da7065231aecb9e3f7a4975ac9d02c33f63f6cae708999f55b195532f90c3a9d
     ? ./types/io.argoproj.workflow.v1alpha1.UserContainer.dhall
 , ValueFrom =
       ./types/io.argoproj.workflow.v1alpha1.ValueFrom.dhall sha256:842a6c74f32dcbe486b6a1b28bacde1881bae689dd84db85e89593a777604d9e
     ? ./types/io.argoproj.workflow.v1alpha1.ValueFrom.dhall
 , Workflow =
-      ./types/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:f3a816e0be2f93d473718234a7a513f7c98d04545a27c2d23c95fceefa7fce86
+      ./types/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:951176b8e0f053e4bf461118aed05464c70809ac4acaf930e6803df79a809445
     ? ./types/io.argoproj.workflow.v1alpha1.Workflow.dhall
 , WorkflowList =
-      ./types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:d129a0637d44d12aa279f98568efa9dd5cda3f4fcdd78090881120a8230f2314
+      ./types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:706eea3450603dc2f8dd79f7e37a5b0f181175ab23a16a5f18b12ad1441d200d
     ? ./types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
 , WorkflowSpec =
-      ./types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:311e15860d311f6a55ff11cdc9a90d9ce15bf9030aad2e68d0d6cb6793fcda8a
+      ./types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:2132a175ca4f36ed9caa0ddc0f95d0bceae991ffe8894369741040fa3082ad26
     ? ./types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
 , WorkflowStep =
       ./types/io.argoproj.workflow.v1alpha1.WorkflowStep.dhall sha256:0664ec08b573d06aef0b726697cc76ec5e0ee0a606e7e2bd3337cb7ee060d06f

--- a/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
+++ b/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
@@ -51,7 +51,7 @@
       )
 , securityContext :
     Optional
-      (   ./io.k8s.api.core.v1.SecurityContext.dhall sha256:2af8194b7c332726b1a90fc36a47aa20f507fedf14e2e238e72153c0e0979798
+      (   ./io.k8s.api.core.v1.SecurityContext.dhall sha256:ae334ad99dfb4d0d69fd0826eab7af27147f0713a7eecccf4b99f697488704c8
         ? ./io.k8s.api.core.v1.SecurityContext.dhall
       )
 , stdin : Optional Bool

--- a/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.Template.dhall
+++ b/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.Template.dhall
@@ -3,7 +3,7 @@
     ? ./io.argoproj.workflow.v1alpha1.ArtifactLocation.dhall
 , initContainers :
     List
-      (   ./io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:20dee8c8a03b7be85600bf83fa468410ae643f7c48d84d08c7b562ced7630e3a
+      (   ./io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:da7065231aecb9e3f7a4975ac9d02c33f63f6cae708999f55b195532f90c3a9d
         ? ./io.argoproj.workflow.v1alpha1.UserContainer.dhall
       )
 , metadata :
@@ -16,7 +16,7 @@
     ? ./io.argoproj.workflow.v1alpha1.RetryStrategy.dhall
 , sidecars :
     List
-      (   ./io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:20dee8c8a03b7be85600bf83fa468410ae643f7c48d84d08c7b562ced7630e3a
+      (   ./io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:da7065231aecb9e3f7a4975ac9d02c33f63f6cae708999f55b195532f90c3a9d
         ? ./io.argoproj.workflow.v1alpha1.UserContainer.dhall
       )
 , steps :
@@ -47,7 +47,7 @@
       )
 , container :
     Optional
-      (   ./io.k8s.api.core.v1.Container.dhall sha256:db5f4f75cf6cf3888c0f7a70deef4493921255eb21bb02098660383d4927051d
+      (   ./io.k8s.api.core.v1.Container.dhall sha256:ad60df4905ca468fd5134fe0267bf255facc227bc5e8a505257f2d57567a13f2
         ? ./io.k8s.api.core.v1.Container.dhall
       )
 , daemon : Optional Bool
@@ -77,7 +77,7 @@
 , schedulerName : Optional Text
 , script :
     Optional
-      (   ./io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:9d26b255c7ef88260efc2415cddde8c69dbefe05c7d59793ec8c82cd6441d551
+      (   ./io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:a15f3aba6b20bf67bdf62c06c420bd04fca0acbd75a20afce4ac59a0cbc70638
         ? ./io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
       )
 }

--- a/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.UserContainer.dhall
+++ b/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.UserContainer.dhall
@@ -51,7 +51,7 @@
       )
 , securityContext :
     Optional
-      (   ./io.k8s.api.core.v1.SecurityContext.dhall sha256:2af8194b7c332726b1a90fc36a47aa20f507fedf14e2e238e72153c0e0979798
+      (   ./io.k8s.api.core.v1.SecurityContext.dhall sha256:ae334ad99dfb4d0d69fd0826eab7af27147f0713a7eecccf4b99f697488704c8
         ? ./io.k8s.api.core.v1.SecurityContext.dhall
       )
 , stdin : Optional Bool

--- a/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.Workflow.dhall
+++ b/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.Workflow.dhall
@@ -1,9 +1,9 @@
 { apiVersion : Text
 , kind : Text
 , metadata :
-      ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall sha256:f0672df8d25dd0e384d486b81d8f551c55d5d6a5868374a5bd35ee0a525f8cee
+      ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall sha256:40ddedcfe9f4f287f399e03629cb298c27d8ec2e5968e18f12677a4dc259c6c3
     ? ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec :
-      ./io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:311e15860d311f6a55ff11cdc9a90d9ce15bf9030aad2e68d0d6cb6793fcda8a
+      ./io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:2132a175ca4f36ed9caa0ddc0f95d0bceae991ffe8894369741040fa3082ad26
     ? ./io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
 }

--- a/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
+++ b/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
@@ -1,11 +1,11 @@
 { apiVersion : Text
 , items :
     List
-      (   ./io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:f3a816e0be2f93d473718234a7a513f7c98d04545a27c2d23c95fceefa7fce86
+      (   ./io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:951176b8e0f053e4bf461118aed05464c70809ac4acaf930e6803df79a809445
         ? ./io.argoproj.workflow.v1alpha1.Workflow.dhall
       )
 , kind : Text
 , metadata :
-      ./io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta.dhall sha256:96b722fff4d997e9c32020312107b8730133ff9aedee32c5a8e30d4b762e9dcb
+      ./io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta.dhall sha256:2c5cb1400b57320ba1035a003efe1fc85d9eee3d40d425d1987523d61415a6de
     ? ./io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta.dhall
 }

--- a/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
+++ b/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
@@ -7,7 +7,7 @@
 , nodeSelector : List { mapKey : Text, mapValue : Text }
 , templates :
     List
-      (   ./io.argoproj.workflow.v1alpha1.Template.dhall sha256:331df1402df98f077c72cd7a40580f5369ca3617d9a499ea92c1d1fe99ed5092
+      (   ./io.argoproj.workflow.v1alpha1.Template.dhall sha256:2119e0d70f4120a310eeef38294b05fd507db6961e357c805752c2214942b48c
         ? ./io.argoproj.workflow.v1alpha1.Template.dhall
       )
 , tolerations :
@@ -17,7 +17,7 @@
       )
 , volumeClaimTemplates :
     List
-      (   ./io.k8s.api.core.v1.PersistentVolumeClaim.dhall sha256:bb3a244115c928544d8287f9fbce5080ac837832b6f08dccebbda7eb5d29e843
+      (   ./io.k8s.api.core.v1.PersistentVolumeClaim.dhall sha256:e26ba9b031f0ec56b4bf4f3b307157797845837ce920bd901fb9c3980a747f39
         ? ./io.k8s.api.core.v1.PersistentVolumeClaim.dhall
       )
 , volumes :

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Affinity.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Affinity.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).Affinity.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.ConfigMapKeySelector.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.ConfigMapKeySelector.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).ConfigMapKeySelector.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Container.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Container.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).Container.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.ContainerPort.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.ContainerPort.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).ContainerPort.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.EnvFromSource.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.EnvFromSource.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).EnvFromSource.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.EnvVar.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.EnvVar.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).EnvVar.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Lifecycle.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Lifecycle.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).Lifecycle.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.LocalObjectReference.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.LocalObjectReference.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).LocalObjectReference.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).PersistentVolumeClaim.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.PodDNSConfig.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.PodDNSConfig.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).PodDNSConfig.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Probe.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Probe.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).Probe.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.ResourceRequirements.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.ResourceRequirements.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).ResourceRequirements.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.SecretKeySelector.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.SecretKeySelector.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).SecretKeySelector.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.SecurityContext.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.SecurityContext.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).SecurityContext.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Toleration.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Toleration.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).Toleration.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Volume.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Volume.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).Volume.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.VolumeDevice.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.VolumeDevice.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).VolumeDevice.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.VolumeMount.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.VolumeMount.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).VolumeMount.Type

--- a/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta.dhall
+++ b/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).ListMeta.Type

--- a/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+++ b/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-  ? ../../k8s/1.14.dhall
+(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+  ? ../../k8s/1.15.dhall
 ).ObjectMeta.Type

--- a/kubernetes/argo/typesUnion.dhall
+++ b/kubernetes/argo/typesUnion.dhall
@@ -74,7 +74,7 @@
       ./types/io.argoproj.workflow.v1alpha1.S3Bucket.dhall sha256:c788453a89be48bf09e5b05bfc9af4ae542d4eeebb28018ade3c1cbab55827e7
     ? ./types/io.argoproj.workflow.v1alpha1.S3Bucket.dhall
 | ScriptTemplate :
-      ./types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:9d26b255c7ef88260efc2415cddde8c69dbefe05c7d59793ec8c82cd6441d551
+      ./types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:a15f3aba6b20bf67bdf62c06c420bd04fca0acbd75a20afce4ac59a0cbc70638
     ? ./types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
 | Sequence :
       ./types/io.argoproj.workflow.v1alpha1.Sequence.dhall sha256:e7cfed05c1b1fe58ce672e268aef05f8fb7e75b9ae3da9e21e2a691a76b5f8ae
@@ -86,22 +86,22 @@
       ./types/io.argoproj.workflow.v1alpha1.TarStrategy.dhall sha256:0912602a19e01dcff30f351958d2d9b69519c9be61b57b1b32a2a569bf8bf5f9
     ? ./types/io.argoproj.workflow.v1alpha1.TarStrategy.dhall
 | Template :
-      ./types/io.argoproj.workflow.v1alpha1.Template.dhall sha256:331df1402df98f077c72cd7a40580f5369ca3617d9a499ea92c1d1fe99ed5092
+      ./types/io.argoproj.workflow.v1alpha1.Template.dhall sha256:2119e0d70f4120a310eeef38294b05fd507db6961e357c805752c2214942b48c
     ? ./types/io.argoproj.workflow.v1alpha1.Template.dhall
 | UserContainer :
-      ./types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:20dee8c8a03b7be85600bf83fa468410ae643f7c48d84d08c7b562ced7630e3a
+      ./types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:da7065231aecb9e3f7a4975ac9d02c33f63f6cae708999f55b195532f90c3a9d
     ? ./types/io.argoproj.workflow.v1alpha1.UserContainer.dhall
 | ValueFrom :
       ./types/io.argoproj.workflow.v1alpha1.ValueFrom.dhall sha256:842a6c74f32dcbe486b6a1b28bacde1881bae689dd84db85e89593a777604d9e
     ? ./types/io.argoproj.workflow.v1alpha1.ValueFrom.dhall
 | Workflow :
-      ./types/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:f3a816e0be2f93d473718234a7a513f7c98d04545a27c2d23c95fceefa7fce86
+      ./types/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:951176b8e0f053e4bf461118aed05464c70809ac4acaf930e6803df79a809445
     ? ./types/io.argoproj.workflow.v1alpha1.Workflow.dhall
 | WorkflowList :
-      ./types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:d129a0637d44d12aa279f98568efa9dd5cda3f4fcdd78090881120a8230f2314
+      ./types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:706eea3450603dc2f8dd79f7e37a5b0f181175ab23a16a5f18b12ad1441d200d
     ? ./types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
 | WorkflowSpec :
-      ./types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:311e15860d311f6a55ff11cdc9a90d9ce15bf9030aad2e68d0d6cb6793fcda8a
+      ./types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:2132a175ca4f36ed9caa0ddc0f95d0bceae991ffe8894369741040fa3082ad26
     ? ./types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
 | WorkflowStep :
       ./types/io.argoproj.workflow.v1alpha1.WorkflowStep.dhall sha256:0664ec08b573d06aef0b726697cc76ec5e0ee0a606e7e2bd3337cb7ee060d06f

--- a/kubernetes/argocd/Application/Type.dhall
+++ b/kubernetes/argocd/Application/Type.dhall
@@ -1,6 +1,6 @@
 let k8s =
-        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../../k8s/1.14.dhall
+        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../../k8s/1.15.dhall
 
 in  { apiVersion : Text
     , kind : Text

--- a/kubernetes/argocd/Application/package.dhall
+++ b/kubernetes/argocd/Application/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:47644abfd824f7f4601c5d43f30c5e047e1c5e8c074b5c778b2a9d0e0e97b692
+      ./Type.dhall sha256:9daa73e9ee313a2a02e9ba492c082e431b02e34fef44349c1719b29531f23bda
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:125060b5c2bb3f832ac3d89aa6cb80a7d688c689854ffdec875fb571923ef8b4

--- a/kubernetes/argocd/Project/Type.dhall
+++ b/kubernetes/argocd/Project/Type.dhall
@@ -1,6 +1,6 @@
 let k8s =
-        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../../k8s/1.14.dhall
+        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../../k8s/1.15.dhall
 
 in  { apiVersion : Text
     , kind : Text

--- a/kubernetes/argocd/Project/package.dhall
+++ b/kubernetes/argocd/Project/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:41537b604e7562bc574a20bee1aa5b4237cce409f295741e2c041bb6c01cad94
+      ./Type.dhall sha256:0afaf220f3beed191477e08c4d31f776fb9eff68be5465da0b867ba85a59ba7b
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:55a47584b90553fdabf3b9c336009d207120cf88f9fd34472d303ea6219e77f3

--- a/kubernetes/argocd/Readme.md
+++ b/kubernetes/argocd/Readme.md
@@ -10,7 +10,7 @@ let argocd =
       https://raw.githubusercontent.com/EarnestResearch/dhall-packages/master/kubernetes/argocd/package.dhall
 
 let k8s =
-      https://raw.githubusercontent.com/EarnestResearch/dhall-packages/master/kubernetes/k8s/1.14.dhall
+      https://raw.githubusercontent.com/EarnestResearch/dhall-packages/master/kubernetes/k8s/1.15.dhall
 
 in  argocd.Application::{
     , metadata = k8s.ObjectMeta::{ name = "guestbook" }

--- a/kubernetes/argocd/TypesUnion.dhall
+++ b/kubernetes/argocd/TypesUnion.dhall
@@ -1,7 +1,7 @@
 < Application :
-      ./Application/Type.dhall sha256:47644abfd824f7f4601c5d43f30c5e047e1c5e8c074b5c778b2a9d0e0e97b692
+      ./Application/Type.dhall sha256:9daa73e9ee313a2a02e9ba492c082e431b02e34fef44349c1719b29531f23bda
     ? ./Application/Type.dhall
 | Project :
-      ./Project/Type.dhall sha256:41537b604e7562bc574a20bee1aa5b4237cce409f295741e2c041bb6c01cad94
+      ./Project/Type.dhall sha256:0afaf220f3beed191477e08c4d31f776fb9eff68be5465da0b867ba85a59ba7b
     ? ./Project/Type.dhall
 >

--- a/kubernetes/argocd/example/app.dhall
+++ b/kubernetes/argocd/example/app.dhall
@@ -1,5 +1,5 @@
 let argocd =
-        ../package.dhall sha256:37659a96e878f98fa6643ec2db53c17dfc9cc388c3a445a979e0310be12e6611
+        ../package.dhall sha256:c7a4e6926237d9e229244f201b330ac53a34c197456b75d3ec54a6f2e5aa384d
       ? ../package.dhall
 
 let config =

--- a/kubernetes/argocd/example/project.dhall
+++ b/kubernetes/argocd/example/project.dhall
@@ -1,10 +1,10 @@
 let argocd =
-        ../package.dhall sha256:37659a96e878f98fa6643ec2db53c17dfc9cc388c3a445a979e0310be12e6611
+        ../package.dhall sha256:c7a4e6926237d9e229244f201b330ac53a34c197456b75d3ec54a6f2e5aa384d
       ? ../package.dhall
 
 let k8s =
-        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../../k8s/1.14.dhall
+        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../../k8s/1.15.dhall
 
 in  argocd.TypesUnion.Project
       argocd.Project::{

--- a/kubernetes/argocd/package.dhall
+++ b/kubernetes/argocd/package.dhall
@@ -1,5 +1,5 @@
 { Application =
-      ./Application/package.dhall sha256:36ddc602d37556fed812b098dbd6efc22062e68418d6b6d2ce8a1f3ff9118067
+      ./Application/package.dhall sha256:a6a0db9570250e7d94e9fcf7e79613fd9e12a5211c70030d58ff24fde2a4f765
     ? ./Application/package.dhall
 , ApplicationSpec =
       ./ApplicationSpec/package.dhall sha256:1fad326e2263f4ee6aa646f576be7b900c8e9ff5b275f1076da2c0a0ea39095f
@@ -41,7 +41,7 @@
       ./PluginSpec/package.dhall sha256:fd9dd420c9ea830231af7e7893ea217f2f7ca35c313cd0a319f80443ac6c84b9
     ? ./PluginSpec/package.dhall
 , Project =
-      ./Project/package.dhall sha256:43e36b1dc0eec92d602643cbee9b21bf5d27b8912cabf8d88a1776b5a5b1f7d8
+      ./Project/package.dhall sha256:94eb236942332300b6b8afcc4767272b156f440479d4bb1af5ac21a0b701f2d2
     ? ./Project/package.dhall
 , ProjectSpec =
       ./ProjectSpec/package.dhall sha256:4c9f9e00802ec63068f267006f3ecb66efbc9c6a927553eafc5862ce30da1f83
@@ -56,9 +56,9 @@
       ./SyncPolicyAutomated/package.dhall sha256:12684bfa3f833c4dd1c502ee5762762642a77e6cffe782ceec071325136215dd
     ? ./SyncPolicyAutomated/package.dhall
 , TypesUnion =
-      ./TypesUnion.dhall sha256:e1ec4a7e47e1182ee7f7308ddd397bfec0ebe4da9188f1a85ff7f062a68b9b71
+      ./TypesUnion.dhall sha256:c1f91d90d8220d11f9ff8d745878da05ca9dc0af20a0792fe70c60c876308fc9
     ? ./TypesUnion.dhall
 , util =
-      ./util/package.dhall sha256:1ed7fad6ed0b031480da4b9f25f3369a48084deb7bf7445bb10a214dbef464b6
+      ./util/package.dhall sha256:4f830ea038c1c8ce07323e8e8ff56d470859f23ab4e7ae6f23e1d6b4b1247fb4
     ? ./util/package.dhall
 }

--- a/kubernetes/argocd/util/internal/makeDhallApp.dhall
+++ b/kubernetes/argocd/util/internal/makeDhallApp.dhall
@@ -5,11 +5,11 @@
     for more information
 -}
 let TypesUnion =
-        ../../TypesUnion.dhall sha256:e1ec4a7e47e1182ee7f7308ddd397bfec0ebe4da9188f1a85ff7f062a68b9b71
+        ../../TypesUnion.dhall sha256:c1f91d90d8220d11f9ff8d745878da05ca9dc0af20a0792fe70c60c876308fc9
       ? ../../TypesUnion.dhall
 
 let Application =
-        ../../Application/package.dhall sha256:36ddc602d37556fed812b098dbd6efc22062e68418d6b6d2ce8a1f3ff9118067
+        ../../Application/package.dhall sha256:a6a0db9570250e7d94e9fcf7e79613fd9e12a5211c70030d58ff24fde2a4f765
       ? ../../Application/package.dhall
 
 let ApplicationSpec =
@@ -29,8 +29,8 @@ let PluginSpec =
       ? ../../PluginSpec/package.dhall
 
 let k8s =
-        ../../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../../../k8s/1.14.dhall
+        ../../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../../../k8s/1.15.dhall
 
 in      \ ( appConfig
           :   ../DhallAppConfig/Type.dhall sha256:b870b087d04ed906a4b912f2333e66fd43db05bdcea36740a6cd707a380b4a72

--- a/kubernetes/argocd/util/internal/makeHelmApp.dhall
+++ b/kubernetes/argocd/util/internal/makeHelmApp.dhall
@@ -1,9 +1,9 @@
 let TypesUnion =
-        ../../TypesUnion.dhall sha256:e1ec4a7e47e1182ee7f7308ddd397bfec0ebe4da9188f1a85ff7f062a68b9b71
+        ../../TypesUnion.dhall sha256:c1f91d90d8220d11f9ff8d745878da05ca9dc0af20a0792fe70c60c876308fc9
       ? ../../TypesUnion.dhall
 
 let Application =
-        ../../Application/package.dhall sha256:36ddc602d37556fed812b098dbd6efc22062e68418d6b6d2ce8a1f3ff9118067
+        ../../Application/package.dhall sha256:a6a0db9570250e7d94e9fcf7e79613fd9e12a5211c70030d58ff24fde2a4f765
       ? ../../Application/package.dhall
 
 let ApplicationSpec =
@@ -23,8 +23,8 @@ let HelmSpec =
       ? ../../HelmSpec/package.dhall
 
 let k8s =
-        ../../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../../../k8s/1.14.dhall
+        ../../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../../../k8s/1.15.dhall
 
 in      \ ( appConfig
           :   ../HelmAppConfig/Type.dhall sha256:a58dc0d542f24958d2f4e4a208317531b749574a35cca08dbf123d059234a02e

--- a/kubernetes/argocd/util/internal/makeKustomizeApp.dhall
+++ b/kubernetes/argocd/util/internal/makeKustomizeApp.dhall
@@ -1,9 +1,9 @@
 let TypesUnion =
-        ../../TypesUnion.dhall sha256:e1ec4a7e47e1182ee7f7308ddd397bfec0ebe4da9188f1a85ff7f062a68b9b71
+        ../../TypesUnion.dhall sha256:c1f91d90d8220d11f9ff8d745878da05ca9dc0af20a0792fe70c60c876308fc9
       ? ../../TypesUnion.dhall
 
 let Application =
-        ../../Application/package.dhall sha256:36ddc602d37556fed812b098dbd6efc22062e68418d6b6d2ce8a1f3ff9118067
+        ../../Application/package.dhall sha256:a6a0db9570250e7d94e9fcf7e79613fd9e12a5211c70030d58ff24fde2a4f765
       ? ../../Application/package.dhall
 
 let ApplicationSpec =
@@ -23,8 +23,8 @@ let KustomizeSpec =
       ? ../../KustomizeSpec/package.dhall
 
 let k8s =
-        ../../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../../../k8s/1.14.dhall
+        ../../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../../../k8s/1.15.dhall
 
 in      \ ( appConfig
           :   ../KustomizeAppConfig/Type.dhall sha256:4a3f8913366c0ac644abbb39626a3b2df997d07fc23a1754d262998c44d89908

--- a/kubernetes/argocd/util/makeApp.dhall
+++ b/kubernetes/argocd/util/makeApp.dhall
@@ -4,13 +4,13 @@
       )
 ->  merge
       { DhallAppConfig =
-            ./internal/makeDhallApp.dhall sha256:c128183443f11de7d2c9c891baefe03e24cef32f471e028e1028c7a2cb04347b
+            ./internal/makeDhallApp.dhall sha256:629a0bee0eeb262d9961cda6b5a2723032e936c9b2e9c65a5f53694484f76ff5
           ? ./internal/makeDhallApp.dhall
       , HelmAppConfig =
-            ./internal/makeHelmApp.dhall sha256:9793ebc5dbc72278a4b8869d78150d2c119632e20dd459a79f05304df695e863
+            ./internal/makeHelmApp.dhall sha256:a224db08bfd698cbdf3b4715bcfca7bf94dfdfa8c253158dc390c5b177fa1cca
           ? ./internal/makeHelmApp.dhall
       , KustomizeAppConfig =
-            ./internal/makeKustomizeApp.dhall sha256:92db8f8599ba8fc05034db9845e6fa23975f3e4f38ec743804ee30e86992485b
+            ./internal/makeKustomizeApp.dhall sha256:01861e0c982d50e79ce4dcad194dc85e235d3a04ec61cefb4337c94b5755fa13
           ? ./internal/makeKustomizeApp.dhall
       }
       appConfig

--- a/kubernetes/argocd/util/package.dhall
+++ b/kubernetes/argocd/util/package.dhall
@@ -1,8 +1,8 @@
 { makeApp =
-      ./makeApp.dhall sha256:d38e67a121410850f0c71f4086d0c1b322ce7df4f1224a63a563997daf26cc64
+      ./makeApp.dhall sha256:5b6c919309b9c5d098bd3569c4a3ebb396c9ac6c4e56e8b428d1b9af82dd2e80
     ? ./makeApp.dhall
 , withSyncWave =
-      ./withSyncWave.dhall sha256:5fdab00cdb41116d4e93fdb49698912fb2eae2d14ded723768bb5ae8d3911c84
+      ./withSyncWave.dhall sha256:46e538c69e72ab64dc92d213cd3dfa7794576bed5fcbd77467e4f4d1ca176a65
     ? ./withSyncWave.dhall
 , AppConfig =
       ./AppConfig.dhall sha256:c610cee69a0557cfb4e4ec51de18a89201a4d7fc4ca2c9a6d4f2372f5c64d968

--- a/kubernetes/argocd/util/withSyncWave.dhall
+++ b/kubernetes/argocd/util/withSyncWave.dhall
@@ -2,19 +2,19 @@
     Utility to add sync waves to argocd applications and projects.
 -}
 let k8s =
-        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../../k8s/1.14.dhall
+        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../../k8s/1.15.dhall
 
 let Project =
-        ../Project/package.dhall sha256:43e36b1dc0eec92d602643cbee9b21bf5d27b8912cabf8d88a1776b5a5b1f7d8
+        ../Project/package.dhall sha256:94eb236942332300b6b8afcc4767272b156f440479d4bb1af5ac21a0b701f2d2
       ? ../Project/package.dhall
 
 let Application =
-        ../Application/package.dhall sha256:36ddc602d37556fed812b098dbd6efc22062e68418d6b6d2ce8a1f3ff9118067
+        ../Application/package.dhall sha256:a6a0db9570250e7d94e9fcf7e79613fd9e12a5211c70030d58ff24fde2a4f765
       ? ../Application/package.dhall
 
 let TypesUnion =
-        ../TypesUnion.dhall sha256:e1ec4a7e47e1182ee7f7308ddd397bfec0ebe4da9188f1a85ff7f062a68b9b71
+        ../TypesUnion.dhall sha256:c1f91d90d8220d11f9ff8d745878da05ca9dc0af20a0792fe70c60c876308fc9
       ? ../TypesUnion.dhall
 
 let withSyncWaveMetadata =

--- a/kubernetes/cert-manager/Certificate/Type.dhall
+++ b/kubernetes/cert-manager/Certificate/Type.dhall
@@ -1,6 +1,6 @@
 let k8s =
-        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../../k8s/1.14.dhall
+        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../../k8s/1.15.dhall
 
 in  { apiVersion : Text
     , kind : Text

--- a/kubernetes/cert-manager/Certificate/package.dhall
+++ b/kubernetes/cert-manager/Certificate/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:f733728c75a3f34d0ab25c2015d3a6bec7ac456222445129570ae5be9adeb42b
+      ./Type.dhall sha256:1dbb054b3c4ae28f734dd89ca2c5cc74ab41c4bd714b1bda90d8d976b39bb09f
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:2a7868780bdf3b207d4fde4fe68df21dd23446ee313e47c5e6f04922a4b0daee

--- a/kubernetes/cert-manager/ClusterIssuer/Type.dhall
+++ b/kubernetes/cert-manager/ClusterIssuer/Type.dhall
@@ -1,6 +1,6 @@
 let k8s =
-        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../../k8s/1.14.dhall
+        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../../k8s/1.15.dhall
 
 in  { apiVersion : Text
     , kind : Text

--- a/kubernetes/cert-manager/ClusterIssuer/package.dhall
+++ b/kubernetes/cert-manager/ClusterIssuer/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:555218cba77ee86d2e2d04b9517da72a44cef92f8bd1b11d307829f2d57f9618
+      ./Type.dhall sha256:dd7f4327c87dfc4bdcc0ec3f709090e0d43169f8a48bbfe15b918319fb695496
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:2df5bda09440cc131439aeec0eb53b61b38946d8e20facea2adedb56ae80db81

--- a/kubernetes/cert-manager/Issuer/Type.dhall
+++ b/kubernetes/cert-manager/Issuer/Type.dhall
@@ -1,6 +1,6 @@
 let k8s =
-        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../../k8s/1.14.dhall
+        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../../k8s/1.15.dhall
 
 in  { apiVersion : Text
     , kind : Text

--- a/kubernetes/cert-manager/Issuer/package.dhall
+++ b/kubernetes/cert-manager/Issuer/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:555218cba77ee86d2e2d04b9517da72a44cef92f8bd1b11d307829f2d57f9618
+      ./Type.dhall sha256:dd7f4327c87dfc4bdcc0ec3f709090e0d43169f8a48bbfe15b918319fb695496
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:066a3a656894ad4817e764584a465e6749d14ca2b608673280cb87bafb4e7dde

--- a/kubernetes/cert-manager/TypesUnion.dhall
+++ b/kubernetes/cert-manager/TypesUnion.dhall
@@ -1,10 +1,10 @@
 < Certificate :
-      ./Certificate/Type.dhall sha256:f733728c75a3f34d0ab25c2015d3a6bec7ac456222445129570ae5be9adeb42b
+      ./Certificate/Type.dhall sha256:1dbb054b3c4ae28f734dd89ca2c5cc74ab41c4bd714b1bda90d8d976b39bb09f
     ? ./Certificate/Type.dhall
 | ClusterIssuer :
-      ./ClusterIssuer/Type.dhall sha256:555218cba77ee86d2e2d04b9517da72a44cef92f8bd1b11d307829f2d57f9618
+      ./ClusterIssuer/Type.dhall sha256:dd7f4327c87dfc4bdcc0ec3f709090e0d43169f8a48bbfe15b918319fb695496
     ? ./ClusterIssuer/Type.dhall
 | Issuer :
-      ./Issuer/Type.dhall sha256:555218cba77ee86d2e2d04b9517da72a44cef92f8bd1b11d307829f2d57f9618
+      ./Issuer/Type.dhall sha256:dd7f4327c87dfc4bdcc0ec3f709090e0d43169f8a48bbfe15b918319fb695496
     ? ./Issuer/Type.dhall
 >

--- a/kubernetes/cert-manager/package.dhall
+++ b/kubernetes/cert-manager/package.dhall
@@ -1,14 +1,14 @@
 { Certificate =
-      ./Certificate/package.dhall sha256:bd3729a219da7bfe237b75cadef2feaee1aedfbc698a26e3c7a415494a2025de
+      ./Certificate/package.dhall sha256:22d521ddc9adeb0db94f2b949b3e59c63b3284eff563c165447430c653efa013
     ? ./Certificate/package.dhall
 , CertificateSpec =
       ./CertificateSpec/package.dhall sha256:c52995abc81eade41829faf4bb55c642a4ff82ab8d9e4abbd6b91a7e546a57f0
     ? ./CertificateSpec/package.dhall
 , ClusterIssuer =
-      ./ClusterIssuer/package.dhall sha256:2068d4ad4ddaa5cd254b167f54f754b551a1bbc9dfa9fa012cb45669d6c2bb31
+      ./ClusterIssuer/package.dhall sha256:0007dc326d9711ee2e03b6b04b313e44d7bf5fc6aa1624f633b541b1841a8475
     ? ./ClusterIssuer/package.dhall
 , Issuer =
-      ./Issuer/package.dhall sha256:acb1f6559f849d6392f1fdb17a9496cf80b2b9f93d3fd7b6f5d0f0222ae454ba
+      ./Issuer/package.dhall sha256:ccf53f714dc9bf59b5e242d52a1f52b0d2d479edc911d7fb9dde51cb182a667c
     ? ./Issuer/package.dhall
 , IssuerSpec =
       ./IssuerSpec/Type.dhall sha256:a444f78e67974acf5936a24860a1913872122003e42732c6c84391f00dc7d2df
@@ -20,6 +20,6 @@
       ./CAIssuerSpec/package.dhall sha256:7648f583fe9765effdb9f80ce73ad8d2d97b4014b7f1bb4caaa91c06e812c79a
     ? ./CAIssuerSpec/package.dhall
 , TypesUnion =
-      ./TypesUnion.dhall sha256:adbe0b8154e8b268f49402045d9ca3b99e73f65108bfd9c49c04b55f8d7e60ac
+      ./TypesUnion.dhall sha256:0bdc251d43e66dcecafb53e10f506435de5a3ada6bad9dae5eba2573b325136a
     ? ./TypesUnion.dhall
 }

--- a/kubernetes/k8s/package.dhall
+++ b/kubernetes/k8s/package.dhall
@@ -1,6 +1,6 @@
 { `1-14` =
-      ./1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-    ? ./1.14.dhall
+      ./1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+    ? ./1.15.dhall
 , `1-15` =
       ./1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
     ? ./1.15.dhall

--- a/kubernetes/kubernetes-external-secrets/ExternalSecret/Type.dhall
+++ b/kubernetes/kubernetes-external-secrets/ExternalSecret/Type.dhall
@@ -1,6 +1,6 @@
 let k8s =
-        ../../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../../k8s/1.14.dhall
+        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../../k8s/1.15.dhall
 
 in  { apiVersion : Text
     , kind : Text

--- a/kubernetes/kubernetes-external-secrets/ExternalSecret/package.dhall
+++ b/kubernetes/kubernetes-external-secrets/ExternalSecret/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:9aae306e00b6726e7fbbedb477e47a7e26c45047c62da3c615d5378d1dc021a8
+      ./Type.dhall sha256:5555b647cc276a5fb9fa36b086b5e3ef0dea6b8dd7045654b40a48e320fcb61a
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:fb479794b0f34d01df52b6c69e684cef045061bf25eb496345dc85968563c231

--- a/kubernetes/kubernetes-external-secrets/package.dhall
+++ b/kubernetes/kubernetes-external-secrets/package.dhall
@@ -2,7 +2,7 @@
       ./BackendType/package.dhall sha256:8a611d85765bbc1962b973518fb2cc14adf28df15be2d12c9b63769d0a8cdc9a
     ? ./BackendType/package.dhall
 , ExternalSecret =
-      ./ExternalSecret/package.dhall sha256:57999e85393c04a74b5432bc37448afcb09ef169fb556bfe6e94b244675df993
+      ./ExternalSecret/package.dhall sha256:6132f56377abd6ab74bd8eefabfb110ec78a487f10d9b8ef56e1430ef88e28c3
     ? ./ExternalSecret/package.dhall
 , SecretsManagerExternalData =
       ./SecretsManagerExternalData/package.dhall sha256:06e4b16d312bf0cade699e35b6204e4f72da8988751665ba9887d75c0712c457

--- a/kubernetes/package.dhall
+++ b/kubernetes/package.dhall
@@ -1,25 +1,25 @@
 { cert-manager =
-      ./cert-manager/package.dhall sha256:84d8acf2650094d5129e8c75b8f6d6c94e5878767949354e4ff6d7eeae5cfe39
+      ./cert-manager/package.dhall sha256:39ea0b4899259b1f92859f2e6b9ccdf151b5623ba9ed01b5f2a0afd8c81b5332
     ? ./cert-manager/package.dhall
 , kubernetes-external-secrets =
-      ./kubernetes-external-secrets/package.dhall sha256:4b52e6019a04f34da8819d85e6f43d5387040fbab102ba88399584fd0b845ee6
+      ./kubernetes-external-secrets/package.dhall sha256:7150f631a6ae9368732b0d6c0db279da1b4b84f3cdfb90270db7c785a4291c07
     ? ./kubernetes-external-secrets/package.dhall
 , k8s =
-      ./k8s/package.dhall sha256:d6d918b7558b4ae5c3774c9a2a460ade08008dd0f458770d8fd81efa0d588aff
+      ./k8s/package.dhall sha256:99637fe8405be855dd75004ac00251f54432cc151c7e64bf13a9e6602513281b
     ? ./k8s/package.dhall
 , argocd =
-      ./argocd/package.dhall sha256:37659a96e878f98fa6643ec2db53c17dfc9cc388c3a445a979e0310be12e6611
+      ./argocd/package.dhall sha256:c7a4e6926237d9e229244f201b330ac53a34c197456b75d3ec54a6f2e5aa384d
     ? ./argocd/package.dhall
 , argo =
-      ./argo/package.dhall sha256:72c8a8f37f102ba5bff6bf68885d2c8f53817dfa4215b702bb9c544582048fa6
+      ./argo/package.dhall sha256:d609a81190e145aa02bdd0e32aa8f018360946883f7a7706066a0fd4c6decc53
     ? ./argo/package.dhall
 , argo-events =
       ./argo-events/package.dhall sha256:06fdc660a4abfc141641cfc58855ad52192b9f93d4d8edbaae2f9aba77d1efc7
     ? ./argo-events/package.dhall
 , ambassador =
-      ./ambassador/package.dhall sha256:cab330e175a5a53fa0ebeaf8087c351ed76e685627b7aade401efffe01c652ec
+      ./ambassador/package.dhall sha256:24f35c2f19dace8e899148f03da017a086334583f7ab4b9a0d73afca9bd6a091
     ? ./ambassador/package.dhall
 , webhook =
-      ./webhook/package.dhall sha256:a64f1ecb837e63b975ea0f0cb0304c926e3d4d3efab92bc6af163cdea6a24561
+      ./webhook/package.dhall sha256:432fbca750183c894f3f094f5ae718d55d5f8769b8621974d4292b4ecb368d01
     ? ./webhook/package.dhall
 }

--- a/kubernetes/webhook/README.md
+++ b/kubernetes/webhook/README.md
@@ -8,7 +8,7 @@ Example:
 -- change the imports to be http imports from this repository
 let Webhook = ./package.dhall
 
-let k8s = ../k8s/1.14.dhall
+let k8s = ../k8s/1.15.dhall
 
 let exampleWebhook =
       Webhook::{

--- a/kubernetes/webhook/Type.dhall
+++ b/kubernetes/webhook/Type.dhall
@@ -1,6 +1,6 @@
 let k8s =
-        ../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../k8s/1.14.dhall
+        ../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../k8s/1.15.dhall
 
 in  { name : Text
     , namespace : Text

--- a/kubernetes/webhook/default.dhall
+++ b/kubernetes/webhook/default.dhall
@@ -1,6 +1,6 @@
 let k8s =
-        ../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../k8s/1.14.dhall
+        ../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../k8s/1.15.dhall
 
 in  { namespaceSelector = None k8s.LabelSelector.Type
     , failurePolicy = None Text

--- a/kubernetes/webhook/example.dhall
+++ b/kubernetes/webhook/example.dhall
@@ -1,10 +1,10 @@
 let Webhook =
-        ./package.dhall sha256:a64f1ecb837e63b975ea0f0cb0304c926e3d4d3efab92bc6af163cdea6a24561
+        ./package.dhall sha256:432fbca750183c894f3f094f5ae718d55d5f8769b8621974d4292b4ecb368d01
       ? ./package.dhall
 
 let k8s =
-        ../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../k8s/1.14.dhall
+        ../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../k8s/1.15.dhall
 
 let exampleWebhook =
       Webhook::{

--- a/kubernetes/webhook/package.dhall
+++ b/kubernetes/webhook/package.dhall
@@ -2,9 +2,9 @@
       ? ./schema.dhall
     )
 /\  { renderMutatingWebhook =
-          ./renderMutatingWebhook.dhall sha256:13d289ee38ea74dca59563294afb662c10edf279f15561f528153f922c2971f2
+          ./renderMutatingWebhook.dhall sha256:3a13bcf027103bb02716dee019d9a79293901c259540d086a89a7f03f64c8552
         ? ./renderMutatingWebhook.dhall
     , renderValidatingWebhook =
-          ./renderValidatingWebhook.dhall sha256:4f3fa3e0b227a632f90c66019dcd3e5d0bf4cb2eb1764b6a066b8e6878a7bc9d
+          ./renderValidatingWebhook.dhall sha256:2935ab3a2569b1a906d415c0db666d6d35e47f14ea30ed9f6fa75413cbef191a
         ? ./renderValidatingWebhook.dhall
     }

--- a/kubernetes/webhook/renderMutatingWebhook.dhall
+++ b/kubernetes/webhook/renderMutatingWebhook.dhall
@@ -1,9 +1,9 @@
 let k8s =
-        ../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../k8s/1.14.dhall
+        ../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../k8s/1.15.dhall
 
 let cert-manager =
-        ../cert-manager/package.dhall sha256:84d8acf2650094d5129e8c75b8f6d6c94e5878767949354e4ff6d7eeae5cfe39
+        ../cert-manager/package.dhall sha256:39ea0b4899259b1f92859f2e6b9ccdf151b5623ba9ed01b5f2a0afd8c81b5332
       ? ../cert-manager/package.dhall
 
 let certsPath = "/certs"
@@ -131,13 +131,14 @@ let mutatingWebhookConfiguration =
                   }
             }
           , webhooks =
-            [ k8s.Webhook::{
+            [ k8s.MutatingWebhook::{
               , name = "${webhook.name}.${webhook.namespace}.svc"
               , clientConfig = k8s.WebhookClientConfig::{
                 , service = Some
                     { name = webhook.name
                     , namespace = webhook.namespace
                     , path = Some webhook.path
+                    , port = Some 443
                     }
                 }
               , failurePolicy = webhook.failurePolicy

--- a/kubernetes/webhook/renderValidatingWebhook.dhall
+++ b/kubernetes/webhook/renderValidatingWebhook.dhall
@@ -1,9 +1,9 @@
 let k8s =
-        ../k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-      ? ../k8s/1.14.dhall
+        ../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? ../k8s/1.15.dhall
 
 let cert-manager =
-        ../cert-manager/package.dhall sha256:84d8acf2650094d5129e8c75b8f6d6c94e5878767949354e4ff6d7eeae5cfe39
+        ../cert-manager/package.dhall sha256:39ea0b4899259b1f92859f2e6b9ccdf151b5623ba9ed01b5f2a0afd8c81b5332
       ? ../cert-manager/package.dhall
 
 let certsPath = "/certs"
@@ -131,13 +131,14 @@ let mutatingWebhookConfiguration =
                   }
             }
           , webhooks =
-            [ k8s.Webhook::{
+            [ k8s.ValidatingWebhook::{
               , name = "${webhook.name}.${webhook.namespace}.svc"
               , clientConfig = k8s.WebhookClientConfig::{
                 , service = Some
                     { name = webhook.name
                     , namespace = webhook.namespace
                     , path = Some webhook.path
+                    , port = Some 443
                     }
                 }
               , failurePolicy = webhook.failurePolicy

--- a/kubernetes/webhook/schema.dhall
+++ b/kubernetes/webhook/schema.dhall
@@ -1,5 +1,6 @@
 let k8s =
-      https://raw.githubusercontent.com/EarnestResearch/dhall-packages/master/kubernetes/k8s/1.14.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
+        https://raw.githubusercontent.com/EarnestResearch/dhall-packages/master/kubernetes/k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ? https://raw.githubusercontent.com/EarnestResearch/dhall-packages/master/kubernetes/k8s/1.15.dhall
 
 let T =
       { name : Text

--- a/package.dhall
+++ b/package.dhall
@@ -1,5 +1,5 @@
 { kubernetes =
-      ./kubernetes/package.dhall sha256:21f920141bbd3284bf3604dbd3f767826551542d680d989804ac63f8f86892fb
+      ./kubernetes/package.dhall sha256:b32f377e169afcfe8bde491321a9ed571c1243491bdfdfa1eb7e84a1f85905ae
     ? ./kubernetes/package.dhall
 , Prelude =
       https://prelude.dhall-lang.org/v12.0.0/package.dhall sha256:aea6817682359ae1939f3a15926b84ad5763c24a3740103202d2eaaea4d01f4c


### PR DESCRIPTION
This upgrades all bindings to use Kubernetes 1.15 since it's available in all the major cloud providers now and 1.14 is EOL.

Partially addresses what discussed on https://github.com/EarnestResearch/dhall-packages/issues/53

