### PR TITLE
update k8s api schema

### DIFF
--- a/kubernetes/ambassador/AuthService/Type.dhall
+++ b/kubernetes/ambassador/AuthService/Type.dhall
@@ -4,7 +4,7 @@
 -}
 
 let k8s =
-        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+        ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
       ? ../../k8s/1.15.dhall
 
 in  { apiVersion : Text

--- a/kubernetes/ambassador/AuthService/package.dhall
+++ b/kubernetes/ambassador/AuthService/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:bbcc9506087f49de445a2fe0f2279a9b48995e1f6ee7f362bb15349e9ff30cec
+      ./Type.dhall sha256:3a6b429568a0e154700f8d2df66299771b2483f099c1a9da7a4643cf04a2d520
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:1ba6e19e9efe37479e887485fd948f45ab988a42ef1edb4a393d8b22ba2eca87

--- a/kubernetes/ambassador/Mapping/Type.dhall
+++ b/kubernetes/ambassador/Mapping/Type.dhall
@@ -5,7 +5,7 @@
 -}
 
 let k8s =
-        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+        ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
       ? ../../k8s/1.15.dhall
 
 in  { apiVersion : Text

--- a/kubernetes/ambassador/Mapping/package.dhall
+++ b/kubernetes/ambassador/Mapping/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:f0b44d9a4d1407a40907791ab320ced86700ca5e624a6286337db8fc66adbbc8
+      ./Type.dhall sha256:0d19434b18ae2bd19646caa450ca003e4c31056ef46329616b4cb9ccfe4105fd
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:77840fc95c95f5c8ac7d5c7f8a8b64615a3930e4de6e337199951a19324f13ba

--- a/kubernetes/ambassador/MappingV2/Type.dhall
+++ b/kubernetes/ambassador/MappingV2/Type.dhall
@@ -5,7 +5,7 @@
 -}
 
 let k8s =
-        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+        ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
       ? ../../k8s/1.15.dhall
 
 in  { apiVersion : Text

--- a/kubernetes/ambassador/MappingV2/package.dhall
+++ b/kubernetes/ambassador/MappingV2/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:901418bbef3218f155d30ac98792797437ea5b0a3dc7509210416444279f810c
+      ./Type.dhall sha256:2d5e8603bb1e6d3a34d88d27afd0c73262bc1c472cb14692bf77c7626d4197e6
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:7e2ca7f1d4a89b214af43ec5144f12cb597923968d814f4489462b4d069d2b67

--- a/kubernetes/ambassador/package.dhall
+++ b/kubernetes/ambassador/package.dhall
@@ -1,5 +1,5 @@
 { AuthService =
-      ./AuthService/package.dhall sha256:8fb6a35ad2a44bc06507623ab50d2b331d39fe20503bf9c5aceba6b410edb042
+      ./AuthService/package.dhall sha256:74954a787751f0639dbbb752a4843c7c0e32f7f3168784ca6927af89961ce8c7
     ? ./AuthService/package.dhall
 , AuthServiceIncludeBody =
       ./AuthServiceIncludeBody/package.dhall sha256:4f65364e68fd4e6059f72a338fc50c92c519839c6e9f452dbc0befdc46e0b75f
@@ -32,13 +32,13 @@
       ./LoadbalancerPolicy/package.dhall sha256:4745eec474d5fee647461c62cc5ad690860f16dfa5a9cf19b6763d127ec72c0c
     ? ./LoadbalancerPolicy/package.dhall
 , Mapping =
-      ./Mapping/package.dhall sha256:b732ca4ef26ef3cbfbb6d8aead811f98bf51c2d74aee5e13ade657b2da9fe2b5
+      ./Mapping/package.dhall sha256:6bf2addbff4b39f94c27269e2d5508b6fb41cb156d299bb99298e61d4ab1657c
     ? ./Mapping/package.dhall
 , MappingSpec =
       ./MappingSpec/package.dhall sha256:ac43b68bd088657681858fe761529135357019bfb55faa09cedf85a0df3780ae
     ? ./MappingSpec/package.dhall
 , MappingV2 =
-      ./MappingV2/package.dhall sha256:63e86cddb5a960bdcd85d9db515ec37dea6f591a68881f9143e0c4ce8faad92c
+      ./MappingV2/package.dhall sha256:722f28e947b0c89e8cdd9711f2bd222fbea94d30b2469b14107cb9db2eff584b
     ? ./MappingV2/package.dhall
 , MappingSpecV2 =
       ./MappingSpecV2/package.dhall sha256:fa039d5cf9e82d6b869f50b59db25ac319e4930b6ace9ad8160418de92639415

--- a/kubernetes/argo/defaults.dhall
+++ b/kubernetes/argo/defaults.dhall
@@ -71,7 +71,7 @@
       ./defaults/io.argoproj.workflow.v1alpha1.S3Bucket.dhall sha256:b2386ff0eb06a6a3b37e4b3337f238d7593232137697f4057784d04203088ff5
     ? ./defaults/io.argoproj.workflow.v1alpha1.S3Bucket.dhall
 , ScriptTemplate =
-      ./defaults/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:2915a675aa3c6294f5788827a54046076756a34f9fc31e9527c9c89ea18cf7cf
+      ./defaults/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:673b273003780c577cd9ddbb81fe590ce2b15b755eb577e37486c7cf40e0fee7
     ? ./defaults/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
 , Sequence =
       ./defaults/io.argoproj.workflow.v1alpha1.Sequence.dhall sha256:e89c73327f41a482a14b764fd3cb1b922f3c28d48967c6f146126b27660b371a
@@ -83,22 +83,22 @@
       ./defaults/io.argoproj.workflow.v1alpha1.TarStrategy.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
     ? ./defaults/io.argoproj.workflow.v1alpha1.TarStrategy.dhall
 , Template =
-      ./defaults/io.argoproj.workflow.v1alpha1.Template.dhall sha256:73aaaec5b0806d5548f46bdc0cbca39e5db5adc664f47a05dda512790c64d478
+      ./defaults/io.argoproj.workflow.v1alpha1.Template.dhall sha256:35d8e8dc93036c6da0cb6e5232cf8e2e4ff59b7f5c24ccc66883396ac88061c7
     ? ./defaults/io.argoproj.workflow.v1alpha1.Template.dhall
 , UserContainer =
-      ./defaults/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:78f1b767410ba41e0e2c5bab41d12b4ca6141566aa2c3dd8b2e3209279490b38
+      ./defaults/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:283db95b501e3faab8e0e9a6746b876cc10830e2c5a711a4cfc109804296aa01
     ? ./defaults/io.argoproj.workflow.v1alpha1.UserContainer.dhall
 , ValueFrom =
       ./defaults/io.argoproj.workflow.v1alpha1.ValueFrom.dhall sha256:555180487c64ec519a9edfab1ecbf4a9ace197e6b781029b2fad639658ec0bd6
     ? ./defaults/io.argoproj.workflow.v1alpha1.ValueFrom.dhall
 , Workflow =
-      ./defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:9ade383df4196cbc43f433c3388042614188017b75dbbbccb405aa0f5fa156e5
+      ./defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:71c1addc26a53284c89b643b2a4d59cc46b9ac7e92aa6c4457a8299d46e00d86
     ? ./defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall
 , WorkflowList =
-      ./defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:af32d1ed1d44b3e9809532b05952fa1003699b90d1fbe790d4c3c010f627926b
+      ./defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:f23d1d29b3d89e644d076f8f87b30ecea87433b791c873d3e5297b405fdef634
     ? ./defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
 , WorkflowSpec =
-      ./defaults/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:73e721a84f0a1be7f8adee32e02becdde3f64162051ba0fa059f2a364743c2dd
+      ./defaults/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:30c472205f50ae1ddc3b6a9b6e0c26533a0e402e02421afde0236b43496e4094
     ? ./defaults/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
 , WorkflowStep =
       ./defaults/io.argoproj.workflow.v1alpha1.WorkflowStep.dhall sha256:90232b03be7ef9b230b94a5310d514a48c33397668e8a9a963a75270b4342f78

--- a/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
+++ b/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
@@ -2,17 +2,17 @@
 , command = [] : List Text
 , env =
     [] : List
-           (   ./../types/io.k8s.api.core.v1.EnvVar.dhall sha256:05e1e15c69097b487387e7e81355cb3e860b9635854aeb57f3068ac6bb629dcb
+           (   ./../types/io.k8s.api.core.v1.EnvVar.dhall sha256:f65fc60c0ee435d1e9e9fb0023420d8286ff27b3a50aa520dbe6b0a22b266783
              ? ./../types/io.k8s.api.core.v1.EnvVar.dhall
            )
 , envFrom =
     [] : List
-           (   ./../types/io.k8s.api.core.v1.EnvFromSource.dhall sha256:90f7afc7134952726f1781b15e2661c03f240530a7dfd0ca0041b9c67d508aac
+           (   ./../types/io.k8s.api.core.v1.EnvFromSource.dhall sha256:dfcc1bb473c7306a41d254589fbc657b21a06c0bae47a411c9d9b7f1b3b07f5d
              ? ./../types/io.k8s.api.core.v1.EnvFromSource.dhall
            )
 , ports =
     [] : List
-           (   ./../types/io.k8s.api.core.v1.ContainerPort.dhall sha256:4e77a1c7092e5ef28542406404e3f44234fa81dea270e09f468e79ba428a575c
+           (   ./../types/io.k8s.api.core.v1.ContainerPort.dhall sha256:9fe52644d6d73a3b3611fc07d0e715b798ca66b722d493145521bc353aaa1db1
              ? ./../types/io.k8s.api.core.v1.ContainerPort.dhall
            )
 , volumeDevices =
@@ -29,27 +29,27 @@
 , imagePullPolicy = None Text
 , lifecycle =
     None
-      (   ./../types/io.k8s.api.core.v1.Lifecycle.dhall sha256:761e28fdc9fbd704c33e47943d81338e2951ad9cd46079181a5c6d4577ce26ce
+      (   ./../types/io.k8s.api.core.v1.Lifecycle.dhall sha256:68b42e890078309297113c05701503a4d25778620bf338533eff4c8066d0995b
         ? ./../types/io.k8s.api.core.v1.Lifecycle.dhall
       )
 , livenessProbe =
     None
-      (   ./../types/io.k8s.api.core.v1.Probe.dhall sha256:f2421c9f700dd50fc6e38dec8a2944e631a1065f70b22697c57410f63172929c
+      (   ./../types/io.k8s.api.core.v1.Probe.dhall sha256:64fba2827fb21955f925b876275d1ed68be04d3e216053ffc385a05f8ab62cde
         ? ./../types/io.k8s.api.core.v1.Probe.dhall
       )
 , readinessProbe =
     None
-      (   ./../types/io.k8s.api.core.v1.Probe.dhall sha256:f2421c9f700dd50fc6e38dec8a2944e631a1065f70b22697c57410f63172929c
+      (   ./../types/io.k8s.api.core.v1.Probe.dhall sha256:64fba2827fb21955f925b876275d1ed68be04d3e216053ffc385a05f8ab62cde
         ? ./../types/io.k8s.api.core.v1.Probe.dhall
       )
 , resources =
     None
-      (   ./../types/io.k8s.api.core.v1.ResourceRequirements.dhall sha256:da094174f6b3fa10b24697e77ef59512cc2e43c538deef203532c36a4cc3dad2
+      (   ./../types/io.k8s.api.core.v1.ResourceRequirements.dhall sha256:e6a52f46fab854b0ba0f7267cbea09584e22585481acfc0959e205dd5f1cb30a
         ? ./../types/io.k8s.api.core.v1.ResourceRequirements.dhall
       )
 , securityContext =
     None
-      (   ./../types/io.k8s.api.core.v1.SecurityContext.dhall sha256:ae334ad99dfb4d0d69fd0826eab7af27147f0713a7eecccf4b99f697488704c8
+      (   ./../types/io.k8s.api.core.v1.SecurityContext.dhall sha256:25fd3cff5ea60651e9987ae5b42a6b0edcb312d69213b6b9093fc205412f8e4b
         ? ./../types/io.k8s.api.core.v1.SecurityContext.dhall
       )
 , stdin = None Bool

--- a/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.Template.dhall
+++ b/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.Template.dhall
@@ -3,7 +3,7 @@
     ? ./io.argoproj.workflow.v1alpha1.ArtifactLocation.dhall
 , initContainers =
     [] : List
-           (   ./../types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:da7065231aecb9e3f7a4975ac9d02c33f63f6cae708999f55b195532f90c3a9d
+           (   ./../types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:03befb7ae18ffb74c4372b0d358c1155d1ed85839c01cf7a641dd31e0ec148ea
              ? ./../types/io.argoproj.workflow.v1alpha1.UserContainer.dhall
            )
 , metadata =
@@ -15,7 +15,7 @@
     ? ./io.argoproj.workflow.v1alpha1.RetryStrategy.dhall
 , sidecars =
     [] : List
-           (   ./../types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:da7065231aecb9e3f7a4975ac9d02c33f63f6cae708999f55b195532f90c3a9d
+           (   ./../types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:03befb7ae18ffb74c4372b0d358c1155d1ed85839c01cf7a641dd31e0ec148ea
              ? ./../types/io.argoproj.workflow.v1alpha1.UserContainer.dhall
            )
 , steps =
@@ -30,23 +30,23 @@
     ? ./io.argoproj.workflow.v1alpha1.SuspendTemplate.dhall
 , tolerations =
     [] : List
-           (   ./../types/io.k8s.api.core.v1.Toleration.dhall sha256:311a6571242358d7b210631d506dc09e89671c2012bee5799c05f0a2c0024d71
+           (   ./../types/io.k8s.api.core.v1.Toleration.dhall sha256:dd6fffae0dd33d31a761843efdd0cebf2673efd4e9be417d17472fddd3055e42
              ? ./../types/io.k8s.api.core.v1.Toleration.dhall
            )
 , volumes =
     [] : List
-           (   ./../types/io.k8s.api.core.v1.Volume.dhall sha256:ab9684be899c5d05b164f59cf5a881fe6fe612a0c1369882edd35cd137f5e68b
+           (   ./../types/io.k8s.api.core.v1.Volume.dhall sha256:aa2b222238a29017213aabfe42fa65f41b8d1301bc48e4a06ff1cc0cc3be7149
              ? ./../types/io.k8s.api.core.v1.Volume.dhall
            )
 , activeDeadlineSeconds = None Natural
 , affinity =
     None
-      (   ./../types/io.k8s.api.core.v1.Affinity.dhall sha256:4f3f951ea9faa62f9a9cd77ba0dc7346c02cc1030c5b9f10e15436704968d925
+      (   ./../types/io.k8s.api.core.v1.Affinity.dhall sha256:bd97be75b0c9c603b8be60ab063f5ddfcc9088db0dde7d0cddb8ff227cdde90a
         ? ./../types/io.k8s.api.core.v1.Affinity.dhall
       )
 , container =
     None
-      (   ./../types/io.k8s.api.core.v1.Container.dhall sha256:ad60df4905ca468fd5134fe0267bf255facc227bc5e8a505257f2d57567a13f2
+      (   ./../types/io.k8s.api.core.v1.Container.dhall sha256:77b5385109379be9fa23ee6d0a576774c9b153b79de9ea1cdd942291cf33dc71
         ? ./../types/io.k8s.api.core.v1.Container.dhall
       )
 , daemon = None Bool
@@ -76,7 +76,7 @@
 , schedulerName = None Text
 , script =
     None
-      (   ./../types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:a15f3aba6b20bf67bdf62c06c420bd04fca0acbd75a20afce4ac59a0cbc70638
+      (   ./../types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:d02e19e7135603cbe66030242fba14136c79efc5af881e3e37dda1b16c9faf1d
         ? ./../types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
       )
 }

--- a/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.UserContainer.dhall
+++ b/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.UserContainer.dhall
@@ -2,17 +2,17 @@
 , command = [] : List Text
 , env =
     [] : List
-           (   ./../types/io.k8s.api.core.v1.EnvVar.dhall sha256:05e1e15c69097b487387e7e81355cb3e860b9635854aeb57f3068ac6bb629dcb
+           (   ./../types/io.k8s.api.core.v1.EnvVar.dhall sha256:f65fc60c0ee435d1e9e9fb0023420d8286ff27b3a50aa520dbe6b0a22b266783
              ? ./../types/io.k8s.api.core.v1.EnvVar.dhall
            )
 , envFrom =
     [] : List
-           (   ./../types/io.k8s.api.core.v1.EnvFromSource.dhall sha256:90f7afc7134952726f1781b15e2661c03f240530a7dfd0ca0041b9c67d508aac
+           (   ./../types/io.k8s.api.core.v1.EnvFromSource.dhall sha256:dfcc1bb473c7306a41d254589fbc657b21a06c0bae47a411c9d9b7f1b3b07f5d
              ? ./../types/io.k8s.api.core.v1.EnvFromSource.dhall
            )
 , ports =
     [] : List
-           (   ./../types/io.k8s.api.core.v1.ContainerPort.dhall sha256:4e77a1c7092e5ef28542406404e3f44234fa81dea270e09f468e79ba428a575c
+           (   ./../types/io.k8s.api.core.v1.ContainerPort.dhall sha256:9fe52644d6d73a3b3611fc07d0e715b798ca66b722d493145521bc353aaa1db1
              ? ./../types/io.k8s.api.core.v1.ContainerPort.dhall
            )
 , volumeDevices =
@@ -29,28 +29,28 @@
 , imagePullPolicy = None Text
 , lifecycle =
     None
-      (   ./../types/io.k8s.api.core.v1.Lifecycle.dhall sha256:761e28fdc9fbd704c33e47943d81338e2951ad9cd46079181a5c6d4577ce26ce
+      (   ./../types/io.k8s.api.core.v1.Lifecycle.dhall sha256:68b42e890078309297113c05701503a4d25778620bf338533eff4c8066d0995b
         ? ./../types/io.k8s.api.core.v1.Lifecycle.dhall
       )
 , livenessProbe =
     None
-      (   ./../types/io.k8s.api.core.v1.Probe.dhall sha256:f2421c9f700dd50fc6e38dec8a2944e631a1065f70b22697c57410f63172929c
+      (   ./../types/io.k8s.api.core.v1.Probe.dhall sha256:64fba2827fb21955f925b876275d1ed68be04d3e216053ffc385a05f8ab62cde
         ? ./../types/io.k8s.api.core.v1.Probe.dhall
       )
 , mirrorVolumeMounts = None Bool
 , readinessProbe =
     None
-      (   ./../types/io.k8s.api.core.v1.Probe.dhall sha256:f2421c9f700dd50fc6e38dec8a2944e631a1065f70b22697c57410f63172929c
+      (   ./../types/io.k8s.api.core.v1.Probe.dhall sha256:64fba2827fb21955f925b876275d1ed68be04d3e216053ffc385a05f8ab62cde
         ? ./../types/io.k8s.api.core.v1.Probe.dhall
       )
 , resources =
     None
-      (   ./../types/io.k8s.api.core.v1.ResourceRequirements.dhall sha256:da094174f6b3fa10b24697e77ef59512cc2e43c538deef203532c36a4cc3dad2
+      (   ./../types/io.k8s.api.core.v1.ResourceRequirements.dhall sha256:e6a52f46fab854b0ba0f7267cbea09584e22585481acfc0959e205dd5f1cb30a
         ? ./../types/io.k8s.api.core.v1.ResourceRequirements.dhall
       )
 , securityContext =
     None
-      (   ./../types/io.k8s.api.core.v1.SecurityContext.dhall sha256:ae334ad99dfb4d0d69fd0826eab7af27147f0713a7eecccf4b99f697488704c8
+      (   ./../types/io.k8s.api.core.v1.SecurityContext.dhall sha256:25fd3cff5ea60651e9987ae5b42a6b0edcb312d69213b6b9093fc205412f8e4b
         ? ./../types/io.k8s.api.core.v1.SecurityContext.dhall
       )
 , stdin = None Bool

--- a/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall
+++ b/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall
@@ -1,6 +1,6 @@
 { apiVersion = "argoproj.io/v1alpha1"
 , kind = "Workflow"
 , spec =
-      ./io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:73e721a84f0a1be7f8adee32e02becdde3f64162051ba0fa059f2a364743c2dd
+      ./io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:30c472205f50ae1ddc3b6a9b6e0c26533a0e402e02421afde0236b43496e4094
     ? ./io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
 }

--- a/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
+++ b/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
@@ -2,7 +2,7 @@
 , kind = "WorkflowList"
 , items =
     [] : List
-           (   ./../types/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:951176b8e0f053e4bf461118aed05464c70809ac4acaf930e6803df79a809445
+           (   ./../types/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:6f43135469ced5656bba4c2b8ff993f88c1419479340ada5b603ea9b37683703
              ? ./../types/io.argoproj.workflow.v1alpha1.Workflow.dhall
            )
 }

--- a/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
+++ b/kubernetes/argo/defaults/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
@@ -6,28 +6,28 @@
 , nodeSelector = [] : List { mapKey : Text, mapValue : Text }
 , templates =
     [] : List
-           (   ./../types/io.argoproj.workflow.v1alpha1.Template.dhall sha256:2119e0d70f4120a310eeef38294b05fd507db6961e357c805752c2214942b48c
+           (   ./../types/io.argoproj.workflow.v1alpha1.Template.dhall sha256:89f75f15a28864f4fbfa2a61e0d0d018a065c06af0fff1413effb1a07cf9095b
              ? ./../types/io.argoproj.workflow.v1alpha1.Template.dhall
            )
 , tolerations =
     [] : List
-           (   ./../types/io.k8s.api.core.v1.Toleration.dhall sha256:311a6571242358d7b210631d506dc09e89671c2012bee5799c05f0a2c0024d71
+           (   ./../types/io.k8s.api.core.v1.Toleration.dhall sha256:dd6fffae0dd33d31a761843efdd0cebf2673efd4e9be417d17472fddd3055e42
              ? ./../types/io.k8s.api.core.v1.Toleration.dhall
            )
 , volumeClaimTemplates =
     [] : List
-           (   ./../types/io.k8s.api.core.v1.PersistentVolumeClaim.dhall sha256:e26ba9b031f0ec56b4bf4f3b307157797845837ce920bd901fb9c3980a747f39
+           (   ./../types/io.k8s.api.core.v1.PersistentVolumeClaim.dhall sha256:a1abe02164340a85c823cc99b149a753674fa4472288f25cdb434e5656669fdd
              ? ./../types/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
            )
 , volumes =
     [] : List
-           (   ./../types/io.k8s.api.core.v1.Volume.dhall sha256:ab9684be899c5d05b164f59cf5a881fe6fe612a0c1369882edd35cd137f5e68b
+           (   ./../types/io.k8s.api.core.v1.Volume.dhall sha256:aa2b222238a29017213aabfe42fa65f41b8d1301bc48e4a06ff1cc0cc3be7149
              ? ./../types/io.k8s.api.core.v1.Volume.dhall
            )
 , activeDeadlineSeconds = None Natural
 , affinity =
     None
-      (   ./../types/io.k8s.api.core.v1.Affinity.dhall sha256:4f3f951ea9faa62f9a9cd77ba0dc7346c02cc1030c5b9f10e15436704968d925
+      (   ./../types/io.k8s.api.core.v1.Affinity.dhall sha256:bd97be75b0c9c603b8be60ab063f5ddfcc9088db0dde7d0cddb8ff227cdde90a
         ? ./../types/io.k8s.api.core.v1.Affinity.dhall
       )
 , arguments =
@@ -37,7 +37,7 @@
       )
 , dnsConfig =
     None
-      (   ./../types/io.k8s.api.core.v1.PodDNSConfig.dhall sha256:ca47223f3f3789a2dbbd5264809a0a1b3144b82b31f13e860fd239ca30e76f5a
+      (   ./../types/io.k8s.api.core.v1.PodDNSConfig.dhall sha256:20fbee72ae47d13233a8bc75a5e701f9cb1ba6fbc60ce66378fab02c38f3a05b
         ? ./../types/io.k8s.api.core.v1.PodDNSConfig.dhall
       )
 , dnsPolicy = None Text

--- a/kubernetes/argo/package.dhall
+++ b/kubernetes/argo/package.dhall
@@ -1,13 +1,13 @@
 { defaults =
-      ./defaults.dhall sha256:db5dad4c38eae6210abd45a29924498e732a67af18e219fa68da60282561c4ec
+      ./defaults.dhall sha256:9f73f5f689b75f7d3deea8fb4d2ce803b79c83fcd6a8c0190b42104eed516085
     ? ./defaults.dhall
 , types =
-      ./types.dhall sha256:1c1c80538951a0ea39a505518546a6b0919e3ec7eef266884bcf0108ee1409fe
+      ./types.dhall sha256:991fa8c626c13d1e2299fffbc6e34bc67e40d38b380a6add86b0085e41a29faa
     ? ./types.dhall
 , typesUnion =
-      ./typesUnion.dhall sha256:d4f9f480047a3dd3054557e7c01a262c52536f114711fb2811079a1c61a15381
+      ./typesUnion.dhall sha256:82e19ae33e686bc7f979456853601666dd161dfec401d35d5e70f7c8ed2beee4
     ? ./typesUnion.dhall
 , schemas =
-      ./schemas.dhall sha256:740e3d6befffa1dee6961e7b74708ba0360ba4c3dcb79adfa2442b9e6b4ea4f9
+      ./schemas.dhall sha256:09ee9785357912dfdc88d28d77e49d92d6e5704fb8ab60e07a701c7c0089fac2
     ? ./schemas.dhall
 }

--- a/kubernetes/argo/schemas.dhall
+++ b/kubernetes/argo/schemas.dhall
@@ -71,7 +71,7 @@
       ./schemas/io.argoproj.workflow.v1alpha1.S3Bucket.dhall sha256:24eb797f2a0b540fbdb1b51f6752d106a8ffa6260bc9b3f7197b0593136ddb67
     ? ./schemas/io.argoproj.workflow.v1alpha1.S3Bucket.dhall
 , ScriptTemplate =
-      ./schemas/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:c3010e987e4b79f662721b9e501c9da045c23d30e4b7512ecc87947032ea600e
+      ./schemas/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:0664a5696ab26aaf973060975f87df900e88f89cc7bcb76fee89c3d91b1580b9
     ? ./schemas/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
 , Sequence =
       ./schemas/io.argoproj.workflow.v1alpha1.Sequence.dhall sha256:07c2d774d97909464b28ebb352b6ae2b3ce487dba17b7db094b53d7e08e1b929
@@ -83,22 +83,22 @@
       ./schemas/io.argoproj.workflow.v1alpha1.TarStrategy.dhall sha256:81a1bf11fb9dc588941bd83400ed571298585a700a53e858456806f7ea3b8ce2
     ? ./schemas/io.argoproj.workflow.v1alpha1.TarStrategy.dhall
 , Template =
-      ./schemas/io.argoproj.workflow.v1alpha1.Template.dhall sha256:f119e07b88f37b386b26824df7f34ae452450261d1446ad8fb8f03a225e5f4fc
+      ./schemas/io.argoproj.workflow.v1alpha1.Template.dhall sha256:bbfd6894e0e98a7417383725bf7c930d46318a94df7eb5afc0bff382e87bc932
     ? ./schemas/io.argoproj.workflow.v1alpha1.Template.dhall
 , UserContainer =
-      ./schemas/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:fde3d3c6775003a0a6096fa0a1ae9028b833df4eebb0310d7b42ae743e99ba36
+      ./schemas/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:939a51b9b4a86e57de7e0438cdb3b3d1c1cb0e8d4e52cb2b96f81300ba4ec3df
     ? ./schemas/io.argoproj.workflow.v1alpha1.UserContainer.dhall
 , ValueFrom =
       ./schemas/io.argoproj.workflow.v1alpha1.ValueFrom.dhall sha256:ae8f89b0fb93156550239aa72d260550c52264946526edb28228d73f5abe8a81
     ? ./schemas/io.argoproj.workflow.v1alpha1.ValueFrom.dhall
 , Workflow =
-      ./schemas/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:9dadcba95364ccf1ea92315b946edb693ce401e1cb17e56b494670db61f25a71
+      ./schemas/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:67a60704704e5c437b2d40d95ce58bff0e9075fea98bf51e50aee0d49af13c06
     ? ./schemas/io.argoproj.workflow.v1alpha1.Workflow.dhall
 , WorkflowList =
-      ./schemas/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:ee3cd7478547c88068c6e78e6e9de609412ccb5d396ca91415de698ac56027c4
+      ./schemas/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:c001aaa14106e8cabebcb7a06a512887a3146c7272b54a318d49a6d1e0af4008
     ? ./schemas/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
 , WorkflowSpec =
-      ./schemas/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:fc4d22776efd8bce1af93154f7747659fb77ddc87482626c29cf438edba7c1d9
+      ./schemas/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:898dcb0392d12ed0468e1875c2d9299bb46f80f72c7cd17ca9444fcb4089eb07
     ? ./schemas/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
 , WorkflowStep =
       ./schemas/io.argoproj.workflow.v1alpha1.WorkflowStep.dhall sha256:c73c9fe3136b55d2af39a8c57df773e067dfda327d5b217271939bbd58a61746

--- a/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
+++ b/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:a15f3aba6b20bf67bdf62c06c420bd04fca0acbd75a20afce4ac59a0cbc70638
+      ./../types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:d02e19e7135603cbe66030242fba14136c79efc5af881e3e37dda1b16c9faf1d
     ? ./../types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
 , default =
-      ./../defaults/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:2915a675aa3c6294f5788827a54046076756a34f9fc31e9527c9c89ea18cf7cf
+      ./../defaults/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:673b273003780c577cd9ddbb81fe590ce2b15b755eb577e37486c7cf40e0fee7
     ? ./../defaults/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
 }

--- a/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.Template.dhall
+++ b/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.Template.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.workflow.v1alpha1.Template.dhall sha256:2119e0d70f4120a310eeef38294b05fd507db6961e357c805752c2214942b48c
+      ./../types/io.argoproj.workflow.v1alpha1.Template.dhall sha256:89f75f15a28864f4fbfa2a61e0d0d018a065c06af0fff1413effb1a07cf9095b
     ? ./../types/io.argoproj.workflow.v1alpha1.Template.dhall
 , default =
-      ./../defaults/io.argoproj.workflow.v1alpha1.Template.dhall sha256:73aaaec5b0806d5548f46bdc0cbca39e5db5adc664f47a05dda512790c64d478
+      ./../defaults/io.argoproj.workflow.v1alpha1.Template.dhall sha256:35d8e8dc93036c6da0cb6e5232cf8e2e4ff59b7f5c24ccc66883396ac88061c7
     ? ./../defaults/io.argoproj.workflow.v1alpha1.Template.dhall
 }

--- a/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.UserContainer.dhall
+++ b/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.UserContainer.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:da7065231aecb9e3f7a4975ac9d02c33f63f6cae708999f55b195532f90c3a9d
+      ./../types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:03befb7ae18ffb74c4372b0d358c1155d1ed85839c01cf7a641dd31e0ec148ea
     ? ./../types/io.argoproj.workflow.v1alpha1.UserContainer.dhall
 , default =
-      ./../defaults/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:78f1b767410ba41e0e2c5bab41d12b4ca6141566aa2c3dd8b2e3209279490b38
+      ./../defaults/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:283db95b501e3faab8e0e9a6746b876cc10830e2c5a711a4cfc109804296aa01
     ? ./../defaults/io.argoproj.workflow.v1alpha1.UserContainer.dhall
 }

--- a/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.Workflow.dhall
+++ b/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.Workflow.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:951176b8e0f053e4bf461118aed05464c70809ac4acaf930e6803df79a809445
+      ./../types/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:6f43135469ced5656bba4c2b8ff993f88c1419479340ada5b603ea9b37683703
     ? ./../types/io.argoproj.workflow.v1alpha1.Workflow.dhall
 , default =
-      ./../defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:9ade383df4196cbc43f433c3388042614188017b75dbbbccb405aa0f5fa156e5
+      ./../defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:71c1addc26a53284c89b643b2a4d59cc46b9ac7e92aa6c4457a8299d46e00d86
     ? ./../defaults/io.argoproj.workflow.v1alpha1.Workflow.dhall
 }

--- a/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
+++ b/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:706eea3450603dc2f8dd79f7e37a5b0f181175ab23a16a5f18b12ad1441d200d
+      ./../types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:0ecaafd2d360ae4d491663528cef2268425631214141b5ac2f46b32cb099e68f
     ? ./../types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
 , default =
-      ./../defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:af32d1ed1d44b3e9809532b05952fa1003699b90d1fbe790d4c3c010f627926b
+      ./../defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:f23d1d29b3d89e644d076f8f87b30ecea87433b791c873d3e5297b405fdef634
     ? ./../defaults/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
 }

--- a/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
+++ b/kubernetes/argo/schemas/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
@@ -1,7 +1,7 @@
 { Type =
-      ./../types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:2132a175ca4f36ed9caa0ddc0f95d0bceae991ffe8894369741040fa3082ad26
+      ./../types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:ccf1b89863747c0ad8fa1f2f67c0dc0f8b0b31a4c20efe6489099b0931216827
     ? ./../types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
 , default =
-      ./../defaults/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:73e721a84f0a1be7f8adee32e02becdde3f64162051ba0fa059f2a364743c2dd
+      ./../defaults/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:30c472205f50ae1ddc3b6a9b6e0c26533a0e402e02421afde0236b43496e4094
     ? ./../defaults/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
 }

--- a/kubernetes/argo/types.dhall
+++ b/kubernetes/argo/types.dhall
@@ -74,7 +74,7 @@
       ./types/io.argoproj.workflow.v1alpha1.S3Bucket.dhall sha256:c788453a89be48bf09e5b05bfc9af4ae542d4eeebb28018ade3c1cbab55827e7
     ? ./types/io.argoproj.workflow.v1alpha1.S3Bucket.dhall
 , ScriptTemplate =
-      ./types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:a15f3aba6b20bf67bdf62c06c420bd04fca0acbd75a20afce4ac59a0cbc70638
+      ./types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:d02e19e7135603cbe66030242fba14136c79efc5af881e3e37dda1b16c9faf1d
     ? ./types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
 , Sequence =
       ./types/io.argoproj.workflow.v1alpha1.Sequence.dhall sha256:e7cfed05c1b1fe58ce672e268aef05f8fb7e75b9ae3da9e21e2a691a76b5f8ae
@@ -86,22 +86,22 @@
       ./types/io.argoproj.workflow.v1alpha1.TarStrategy.dhall sha256:0912602a19e01dcff30f351958d2d9b69519c9be61b57b1b32a2a569bf8bf5f9
     ? ./types/io.argoproj.workflow.v1alpha1.TarStrategy.dhall
 , Template =
-      ./types/io.argoproj.workflow.v1alpha1.Template.dhall sha256:2119e0d70f4120a310eeef38294b05fd507db6961e357c805752c2214942b48c
+      ./types/io.argoproj.workflow.v1alpha1.Template.dhall sha256:89f75f15a28864f4fbfa2a61e0d0d018a065c06af0fff1413effb1a07cf9095b
     ? ./types/io.argoproj.workflow.v1alpha1.Template.dhall
 , UserContainer =
-      ./types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:da7065231aecb9e3f7a4975ac9d02c33f63f6cae708999f55b195532f90c3a9d
+      ./types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:03befb7ae18ffb74c4372b0d358c1155d1ed85839c01cf7a641dd31e0ec148ea
     ? ./types/io.argoproj.workflow.v1alpha1.UserContainer.dhall
 , ValueFrom =
       ./types/io.argoproj.workflow.v1alpha1.ValueFrom.dhall sha256:842a6c74f32dcbe486b6a1b28bacde1881bae689dd84db85e89593a777604d9e
     ? ./types/io.argoproj.workflow.v1alpha1.ValueFrom.dhall
 , Workflow =
-      ./types/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:951176b8e0f053e4bf461118aed05464c70809ac4acaf930e6803df79a809445
+      ./types/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:6f43135469ced5656bba4c2b8ff993f88c1419479340ada5b603ea9b37683703
     ? ./types/io.argoproj.workflow.v1alpha1.Workflow.dhall
 , WorkflowList =
-      ./types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:706eea3450603dc2f8dd79f7e37a5b0f181175ab23a16a5f18b12ad1441d200d
+      ./types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:0ecaafd2d360ae4d491663528cef2268425631214141b5ac2f46b32cb099e68f
     ? ./types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
 , WorkflowSpec =
-      ./types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:2132a175ca4f36ed9caa0ddc0f95d0bceae991ffe8894369741040fa3082ad26
+      ./types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:ccf1b89863747c0ad8fa1f2f67c0dc0f8b0b31a4c20efe6489099b0931216827
     ? ./types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
 , WorkflowStep =
       ./types/io.argoproj.workflow.v1alpha1.WorkflowStep.dhall sha256:0664ec08b573d06aef0b726697cc76ec5e0ee0a606e7e2bd3337cb7ee060d06f

--- a/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
+++ b/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
@@ -2,18 +2,18 @@
 , command : List Text
 , env :
     List
-      (   ./io.k8s.api.core.v1.EnvVar.dhall sha256:05e1e15c69097b487387e7e81355cb3e860b9635854aeb57f3068ac6bb629dcb
+      (   ./io.k8s.api.core.v1.EnvVar.dhall sha256:f65fc60c0ee435d1e9e9fb0023420d8286ff27b3a50aa520dbe6b0a22b266783
         ? ./io.k8s.api.core.v1.EnvVar.dhall
       )
 , envFrom :
     List
-      (   ./io.k8s.api.core.v1.EnvFromSource.dhall sha256:90f7afc7134952726f1781b15e2661c03f240530a7dfd0ca0041b9c67d508aac
+      (   ./io.k8s.api.core.v1.EnvFromSource.dhall sha256:dfcc1bb473c7306a41d254589fbc657b21a06c0bae47a411c9d9b7f1b3b07f5d
         ? ./io.k8s.api.core.v1.EnvFromSource.dhall
       )
 , name : Text
 , ports :
     List
-      (   ./io.k8s.api.core.v1.ContainerPort.dhall sha256:4e77a1c7092e5ef28542406404e3f44234fa81dea270e09f468e79ba428a575c
+      (   ./io.k8s.api.core.v1.ContainerPort.dhall sha256:9fe52644d6d73a3b3611fc07d0e715b798ca66b722d493145521bc353aaa1db1
         ? ./io.k8s.api.core.v1.ContainerPort.dhall
       )
 , source : Text
@@ -31,27 +31,27 @@
 , imagePullPolicy : Optional Text
 , lifecycle :
     Optional
-      (   ./io.k8s.api.core.v1.Lifecycle.dhall sha256:761e28fdc9fbd704c33e47943d81338e2951ad9cd46079181a5c6d4577ce26ce
+      (   ./io.k8s.api.core.v1.Lifecycle.dhall sha256:68b42e890078309297113c05701503a4d25778620bf338533eff4c8066d0995b
         ? ./io.k8s.api.core.v1.Lifecycle.dhall
       )
 , livenessProbe :
     Optional
-      (   ./io.k8s.api.core.v1.Probe.dhall sha256:f2421c9f700dd50fc6e38dec8a2944e631a1065f70b22697c57410f63172929c
+      (   ./io.k8s.api.core.v1.Probe.dhall sha256:64fba2827fb21955f925b876275d1ed68be04d3e216053ffc385a05f8ab62cde
         ? ./io.k8s.api.core.v1.Probe.dhall
       )
 , readinessProbe :
     Optional
-      (   ./io.k8s.api.core.v1.Probe.dhall sha256:f2421c9f700dd50fc6e38dec8a2944e631a1065f70b22697c57410f63172929c
+      (   ./io.k8s.api.core.v1.Probe.dhall sha256:64fba2827fb21955f925b876275d1ed68be04d3e216053ffc385a05f8ab62cde
         ? ./io.k8s.api.core.v1.Probe.dhall
       )
 , resources :
     Optional
-      (   ./io.k8s.api.core.v1.ResourceRequirements.dhall sha256:da094174f6b3fa10b24697e77ef59512cc2e43c538deef203532c36a4cc3dad2
+      (   ./io.k8s.api.core.v1.ResourceRequirements.dhall sha256:e6a52f46fab854b0ba0f7267cbea09584e22585481acfc0959e205dd5f1cb30a
         ? ./io.k8s.api.core.v1.ResourceRequirements.dhall
       )
 , securityContext :
     Optional
-      (   ./io.k8s.api.core.v1.SecurityContext.dhall sha256:ae334ad99dfb4d0d69fd0826eab7af27147f0713a7eecccf4b99f697488704c8
+      (   ./io.k8s.api.core.v1.SecurityContext.dhall sha256:25fd3cff5ea60651e9987ae5b42a6b0edcb312d69213b6b9093fc205412f8e4b
         ? ./io.k8s.api.core.v1.SecurityContext.dhall
       )
 , stdin : Optional Bool

--- a/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.Template.dhall
+++ b/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.Template.dhall
@@ -3,7 +3,7 @@
     ? ./io.argoproj.workflow.v1alpha1.ArtifactLocation.dhall
 , initContainers :
     List
-      (   ./io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:da7065231aecb9e3f7a4975ac9d02c33f63f6cae708999f55b195532f90c3a9d
+      (   ./io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:03befb7ae18ffb74c4372b0d358c1155d1ed85839c01cf7a641dd31e0ec148ea
         ? ./io.argoproj.workflow.v1alpha1.UserContainer.dhall
       )
 , metadata :
@@ -16,7 +16,7 @@
     ? ./io.argoproj.workflow.v1alpha1.RetryStrategy.dhall
 , sidecars :
     List
-      (   ./io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:da7065231aecb9e3f7a4975ac9d02c33f63f6cae708999f55b195532f90c3a9d
+      (   ./io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:03befb7ae18ffb74c4372b0d358c1155d1ed85839c01cf7a641dd31e0ec148ea
         ? ./io.argoproj.workflow.v1alpha1.UserContainer.dhall
       )
 , steps :
@@ -31,23 +31,23 @@
     ? ./io.argoproj.workflow.v1alpha1.SuspendTemplate.dhall
 , tolerations :
     List
-      (   ./io.k8s.api.core.v1.Toleration.dhall sha256:311a6571242358d7b210631d506dc09e89671c2012bee5799c05f0a2c0024d71
+      (   ./io.k8s.api.core.v1.Toleration.dhall sha256:dd6fffae0dd33d31a761843efdd0cebf2673efd4e9be417d17472fddd3055e42
         ? ./io.k8s.api.core.v1.Toleration.dhall
       )
 , volumes :
     List
-      (   ./io.k8s.api.core.v1.Volume.dhall sha256:ab9684be899c5d05b164f59cf5a881fe6fe612a0c1369882edd35cd137f5e68b
+      (   ./io.k8s.api.core.v1.Volume.dhall sha256:aa2b222238a29017213aabfe42fa65f41b8d1301bc48e4a06ff1cc0cc3be7149
         ? ./io.k8s.api.core.v1.Volume.dhall
       )
 , activeDeadlineSeconds : Optional Natural
 , affinity :
     Optional
-      (   ./io.k8s.api.core.v1.Affinity.dhall sha256:4f3f951ea9faa62f9a9cd77ba0dc7346c02cc1030c5b9f10e15436704968d925
+      (   ./io.k8s.api.core.v1.Affinity.dhall sha256:bd97be75b0c9c603b8be60ab063f5ddfcc9088db0dde7d0cddb8ff227cdde90a
         ? ./io.k8s.api.core.v1.Affinity.dhall
       )
 , container :
     Optional
-      (   ./io.k8s.api.core.v1.Container.dhall sha256:ad60df4905ca468fd5134fe0267bf255facc227bc5e8a505257f2d57567a13f2
+      (   ./io.k8s.api.core.v1.Container.dhall sha256:77b5385109379be9fa23ee6d0a576774c9b153b79de9ea1cdd942291cf33dc71
         ? ./io.k8s.api.core.v1.Container.dhall
       )
 , daemon : Optional Bool
@@ -77,7 +77,7 @@
 , schedulerName : Optional Text
 , script :
     Optional
-      (   ./io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:a15f3aba6b20bf67bdf62c06c420bd04fca0acbd75a20afce4ac59a0cbc70638
+      (   ./io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:d02e19e7135603cbe66030242fba14136c79efc5af881e3e37dda1b16c9faf1d
         ? ./io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
       )
 }

--- a/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.UserContainer.dhall
+++ b/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.UserContainer.dhall
@@ -2,18 +2,18 @@
 , command : List Text
 , env :
     List
-      (   ./io.k8s.api.core.v1.EnvVar.dhall sha256:05e1e15c69097b487387e7e81355cb3e860b9635854aeb57f3068ac6bb629dcb
+      (   ./io.k8s.api.core.v1.EnvVar.dhall sha256:f65fc60c0ee435d1e9e9fb0023420d8286ff27b3a50aa520dbe6b0a22b266783
         ? ./io.k8s.api.core.v1.EnvVar.dhall
       )
 , envFrom :
     List
-      (   ./io.k8s.api.core.v1.EnvFromSource.dhall sha256:90f7afc7134952726f1781b15e2661c03f240530a7dfd0ca0041b9c67d508aac
+      (   ./io.k8s.api.core.v1.EnvFromSource.dhall sha256:dfcc1bb473c7306a41d254589fbc657b21a06c0bae47a411c9d9b7f1b3b07f5d
         ? ./io.k8s.api.core.v1.EnvFromSource.dhall
       )
 , name : Text
 , ports :
     List
-      (   ./io.k8s.api.core.v1.ContainerPort.dhall sha256:4e77a1c7092e5ef28542406404e3f44234fa81dea270e09f468e79ba428a575c
+      (   ./io.k8s.api.core.v1.ContainerPort.dhall sha256:9fe52644d6d73a3b3611fc07d0e715b798ca66b722d493145521bc353aaa1db1
         ? ./io.k8s.api.core.v1.ContainerPort.dhall
       )
 , volumeDevices :
@@ -30,28 +30,28 @@
 , imagePullPolicy : Optional Text
 , lifecycle :
     Optional
-      (   ./io.k8s.api.core.v1.Lifecycle.dhall sha256:761e28fdc9fbd704c33e47943d81338e2951ad9cd46079181a5c6d4577ce26ce
+      (   ./io.k8s.api.core.v1.Lifecycle.dhall sha256:68b42e890078309297113c05701503a4d25778620bf338533eff4c8066d0995b
         ? ./io.k8s.api.core.v1.Lifecycle.dhall
       )
 , livenessProbe :
     Optional
-      (   ./io.k8s.api.core.v1.Probe.dhall sha256:f2421c9f700dd50fc6e38dec8a2944e631a1065f70b22697c57410f63172929c
+      (   ./io.k8s.api.core.v1.Probe.dhall sha256:64fba2827fb21955f925b876275d1ed68be04d3e216053ffc385a05f8ab62cde
         ? ./io.k8s.api.core.v1.Probe.dhall
       )
 , mirrorVolumeMounts : Optional Bool
 , readinessProbe :
     Optional
-      (   ./io.k8s.api.core.v1.Probe.dhall sha256:f2421c9f700dd50fc6e38dec8a2944e631a1065f70b22697c57410f63172929c
+      (   ./io.k8s.api.core.v1.Probe.dhall sha256:64fba2827fb21955f925b876275d1ed68be04d3e216053ffc385a05f8ab62cde
         ? ./io.k8s.api.core.v1.Probe.dhall
       )
 , resources :
     Optional
-      (   ./io.k8s.api.core.v1.ResourceRequirements.dhall sha256:da094174f6b3fa10b24697e77ef59512cc2e43c538deef203532c36a4cc3dad2
+      (   ./io.k8s.api.core.v1.ResourceRequirements.dhall sha256:e6a52f46fab854b0ba0f7267cbea09584e22585481acfc0959e205dd5f1cb30a
         ? ./io.k8s.api.core.v1.ResourceRequirements.dhall
       )
 , securityContext :
     Optional
-      (   ./io.k8s.api.core.v1.SecurityContext.dhall sha256:ae334ad99dfb4d0d69fd0826eab7af27147f0713a7eecccf4b99f697488704c8
+      (   ./io.k8s.api.core.v1.SecurityContext.dhall sha256:25fd3cff5ea60651e9987ae5b42a6b0edcb312d69213b6b9093fc205412f8e4b
         ? ./io.k8s.api.core.v1.SecurityContext.dhall
       )
 , stdin : Optional Bool

--- a/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.Workflow.dhall
+++ b/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.Workflow.dhall
@@ -1,9 +1,9 @@
 { apiVersion : Text
 , kind : Text
 , metadata :
-      ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall sha256:40ddedcfe9f4f287f399e03629cb298c27d8ec2e5968e18f12677a4dc259c6c3
+      ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall sha256:7c929555fdfccc77b69f983789c73337cd4e90460568d996a7c23f34605f0f0f
     ? ./io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
 , spec :
-      ./io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:2132a175ca4f36ed9caa0ddc0f95d0bceae991ffe8894369741040fa3082ad26
+      ./io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:ccf1b89863747c0ad8fa1f2f67c0dc0f8b0b31a4c20efe6489099b0931216827
     ? ./io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
 }

--- a/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
+++ b/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
@@ -1,11 +1,11 @@
 { apiVersion : Text
 , items :
     List
-      (   ./io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:951176b8e0f053e4bf461118aed05464c70809ac4acaf930e6803df79a809445
+      (   ./io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:6f43135469ced5656bba4c2b8ff993f88c1419479340ada5b603ea9b37683703
         ? ./io.argoproj.workflow.v1alpha1.Workflow.dhall
       )
 , kind : Text
 , metadata :
-      ./io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta.dhall sha256:2c5cb1400b57320ba1035a003efe1fc85d9eee3d40d425d1987523d61415a6de
+      ./io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta.dhall sha256:6eff47294815ae850d3e11a619c955c8024c8d0702cd70777922b02d587653bc
     ? ./io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta.dhall
 }

--- a/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
+++ b/kubernetes/argo/types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
@@ -7,28 +7,28 @@
 , nodeSelector : List { mapKey : Text, mapValue : Text }
 , templates :
     List
-      (   ./io.argoproj.workflow.v1alpha1.Template.dhall sha256:2119e0d70f4120a310eeef38294b05fd507db6961e357c805752c2214942b48c
+      (   ./io.argoproj.workflow.v1alpha1.Template.dhall sha256:89f75f15a28864f4fbfa2a61e0d0d018a065c06af0fff1413effb1a07cf9095b
         ? ./io.argoproj.workflow.v1alpha1.Template.dhall
       )
 , tolerations :
     List
-      (   ./io.k8s.api.core.v1.Toleration.dhall sha256:311a6571242358d7b210631d506dc09e89671c2012bee5799c05f0a2c0024d71
+      (   ./io.k8s.api.core.v1.Toleration.dhall sha256:dd6fffae0dd33d31a761843efdd0cebf2673efd4e9be417d17472fddd3055e42
         ? ./io.k8s.api.core.v1.Toleration.dhall
       )
 , volumeClaimTemplates :
     List
-      (   ./io.k8s.api.core.v1.PersistentVolumeClaim.dhall sha256:e26ba9b031f0ec56b4bf4f3b307157797845837ce920bd901fb9c3980a747f39
+      (   ./io.k8s.api.core.v1.PersistentVolumeClaim.dhall sha256:a1abe02164340a85c823cc99b149a753674fa4472288f25cdb434e5656669fdd
         ? ./io.k8s.api.core.v1.PersistentVolumeClaim.dhall
       )
 , volumes :
     List
-      (   ./io.k8s.api.core.v1.Volume.dhall sha256:ab9684be899c5d05b164f59cf5a881fe6fe612a0c1369882edd35cd137f5e68b
+      (   ./io.k8s.api.core.v1.Volume.dhall sha256:aa2b222238a29017213aabfe42fa65f41b8d1301bc48e4a06ff1cc0cc3be7149
         ? ./io.k8s.api.core.v1.Volume.dhall
       )
 , activeDeadlineSeconds : Optional Natural
 , affinity :
     Optional
-      (   ./io.k8s.api.core.v1.Affinity.dhall sha256:4f3f951ea9faa62f9a9cd77ba0dc7346c02cc1030c5b9f10e15436704968d925
+      (   ./io.k8s.api.core.v1.Affinity.dhall sha256:bd97be75b0c9c603b8be60ab063f5ddfcc9088db0dde7d0cddb8ff227cdde90a
         ? ./io.k8s.api.core.v1.Affinity.dhall
       )
 , arguments :
@@ -38,7 +38,7 @@
       )
 , dnsConfig :
     Optional
-      (   ./io.k8s.api.core.v1.PodDNSConfig.dhall sha256:ca47223f3f3789a2dbbd5264809a0a1b3144b82b31f13e860fd239ca30e76f5a
+      (   ./io.k8s.api.core.v1.PodDNSConfig.dhall sha256:20fbee72ae47d13233a8bc75a5e701f9cb1ba6fbc60ce66378fab02c38f3a05b
         ? ./io.k8s.api.core.v1.PodDNSConfig.dhall
       )
 , dnsPolicy : Optional Text

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Affinity.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Affinity.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).Affinity.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.ConfigMapKeySelector.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.ConfigMapKeySelector.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).ConfigMapKeySelector.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Container.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Container.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).Container.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.ContainerPort.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.ContainerPort.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).ContainerPort.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.EnvFromSource.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.EnvFromSource.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).EnvFromSource.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.EnvVar.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.EnvVar.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).EnvVar.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Lifecycle.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Lifecycle.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).Lifecycle.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.LocalObjectReference.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.LocalObjectReference.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).LocalObjectReference.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).PersistentVolumeClaim.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.PodDNSConfig.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.PodDNSConfig.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).PodDNSConfig.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Probe.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Probe.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).Probe.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.ResourceRequirements.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.ResourceRequirements.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).ResourceRequirements.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.SecretKeySelector.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.SecretKeySelector.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).SecretKeySelector.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.SecurityContext.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.SecurityContext.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).SecurityContext.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Toleration.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Toleration.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).Toleration.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.Volume.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.Volume.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).Volume.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.VolumeDevice.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.VolumeDevice.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).VolumeDevice.Type

--- a/kubernetes/argo/types/io.k8s.api.core.v1.VolumeMount.dhall
+++ b/kubernetes/argo/types/io.k8s.api.core.v1.VolumeMount.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).VolumeMount.Type

--- a/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta.dhall
+++ b/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).ListMeta.Type

--- a/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+++ b/kubernetes/argo/types/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
@@ -1,3 +1,3 @@
-(   ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+(   ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
   ? ../../k8s/1.15.dhall
 ).ObjectMeta.Type

--- a/kubernetes/argo/typesUnion.dhall
+++ b/kubernetes/argo/typesUnion.dhall
@@ -74,7 +74,7 @@
       ./types/io.argoproj.workflow.v1alpha1.S3Bucket.dhall sha256:c788453a89be48bf09e5b05bfc9af4ae542d4eeebb28018ade3c1cbab55827e7
     ? ./types/io.argoproj.workflow.v1alpha1.S3Bucket.dhall
 | ScriptTemplate :
-      ./types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:a15f3aba6b20bf67bdf62c06c420bd04fca0acbd75a20afce4ac59a0cbc70638
+      ./types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall sha256:d02e19e7135603cbe66030242fba14136c79efc5af881e3e37dda1b16c9faf1d
     ? ./types/io.argoproj.workflow.v1alpha1.ScriptTemplate.dhall
 | Sequence :
       ./types/io.argoproj.workflow.v1alpha1.Sequence.dhall sha256:e7cfed05c1b1fe58ce672e268aef05f8fb7e75b9ae3da9e21e2a691a76b5f8ae
@@ -86,22 +86,22 @@
       ./types/io.argoproj.workflow.v1alpha1.TarStrategy.dhall sha256:0912602a19e01dcff30f351958d2d9b69519c9be61b57b1b32a2a569bf8bf5f9
     ? ./types/io.argoproj.workflow.v1alpha1.TarStrategy.dhall
 | Template :
-      ./types/io.argoproj.workflow.v1alpha1.Template.dhall sha256:2119e0d70f4120a310eeef38294b05fd507db6961e357c805752c2214942b48c
+      ./types/io.argoproj.workflow.v1alpha1.Template.dhall sha256:89f75f15a28864f4fbfa2a61e0d0d018a065c06af0fff1413effb1a07cf9095b
     ? ./types/io.argoproj.workflow.v1alpha1.Template.dhall
 | UserContainer :
-      ./types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:da7065231aecb9e3f7a4975ac9d02c33f63f6cae708999f55b195532f90c3a9d
+      ./types/io.argoproj.workflow.v1alpha1.UserContainer.dhall sha256:03befb7ae18ffb74c4372b0d358c1155d1ed85839c01cf7a641dd31e0ec148ea
     ? ./types/io.argoproj.workflow.v1alpha1.UserContainer.dhall
 | ValueFrom :
       ./types/io.argoproj.workflow.v1alpha1.ValueFrom.dhall sha256:842a6c74f32dcbe486b6a1b28bacde1881bae689dd84db85e89593a777604d9e
     ? ./types/io.argoproj.workflow.v1alpha1.ValueFrom.dhall
 | Workflow :
-      ./types/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:951176b8e0f053e4bf461118aed05464c70809ac4acaf930e6803df79a809445
+      ./types/io.argoproj.workflow.v1alpha1.Workflow.dhall sha256:6f43135469ced5656bba4c2b8ff993f88c1419479340ada5b603ea9b37683703
     ? ./types/io.argoproj.workflow.v1alpha1.Workflow.dhall
 | WorkflowList :
-      ./types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:706eea3450603dc2f8dd79f7e37a5b0f181175ab23a16a5f18b12ad1441d200d
+      ./types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall sha256:0ecaafd2d360ae4d491663528cef2268425631214141b5ac2f46b32cb099e68f
     ? ./types/io.argoproj.workflow.v1alpha1.WorkflowList.dhall
 | WorkflowSpec :
-      ./types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:2132a175ca4f36ed9caa0ddc0f95d0bceae991ffe8894369741040fa3082ad26
+      ./types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall sha256:ccf1b89863747c0ad8fa1f2f67c0dc0f8b0b31a4c20efe6489099b0931216827
     ? ./types/io.argoproj.workflow.v1alpha1.WorkflowSpec.dhall
 | WorkflowStep :
       ./types/io.argoproj.workflow.v1alpha1.WorkflowStep.dhall sha256:0664ec08b573d06aef0b726697cc76ec5e0ee0a606e7e2bd3337cb7ee060d06f

--- a/kubernetes/argocd/Application/Type.dhall
+++ b/kubernetes/argocd/Application/Type.dhall
@@ -1,5 +1,5 @@
 let k8s =
-        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+        ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
       ? ../../k8s/1.15.dhall
 
 in  { apiVersion : Text

--- a/kubernetes/argocd/Application/package.dhall
+++ b/kubernetes/argocd/Application/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:9daa73e9ee313a2a02e9ba492c082e431b02e34fef44349c1719b29531f23bda
+      ./Type.dhall sha256:7e7003ce76c5d13b68c6ff5779803a78198d59340471799c976c11982aba0165
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:125060b5c2bb3f832ac3d89aa6cb80a7d688c689854ffdec875fb571923ef8b4

--- a/kubernetes/argocd/Project/Type.dhall
+++ b/kubernetes/argocd/Project/Type.dhall
@@ -1,5 +1,5 @@
 let k8s =
-        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+        ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
       ? ../../k8s/1.15.dhall
 
 in  { apiVersion : Text

--- a/kubernetes/argocd/Project/package.dhall
+++ b/kubernetes/argocd/Project/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:0afaf220f3beed191477e08c4d31f776fb9eff68be5465da0b867ba85a59ba7b
+      ./Type.dhall sha256:3746caa4b2245d3a0cd8e7a1b625840512b0c0579612ed9fa594c21c7673d0e7
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:55a47584b90553fdabf3b9c336009d207120cf88f9fd34472d303ea6219e77f3

--- a/kubernetes/argocd/TypesUnion.dhall
+++ b/kubernetes/argocd/TypesUnion.dhall
@@ -1,7 +1,7 @@
 < Application :
-      ./Application/Type.dhall sha256:9daa73e9ee313a2a02e9ba492c082e431b02e34fef44349c1719b29531f23bda
+      ./Application/Type.dhall sha256:7e7003ce76c5d13b68c6ff5779803a78198d59340471799c976c11982aba0165
     ? ./Application/Type.dhall
 | Project :
-      ./Project/Type.dhall sha256:0afaf220f3beed191477e08c4d31f776fb9eff68be5465da0b867ba85a59ba7b
+      ./Project/Type.dhall sha256:3746caa4b2245d3a0cd8e7a1b625840512b0c0579612ed9fa594c21c7673d0e7
     ? ./Project/Type.dhall
 >

--- a/kubernetes/argocd/example/app.dhall
+++ b/kubernetes/argocd/example/app.dhall
@@ -1,5 +1,5 @@
 let argocd =
-        ../package.dhall sha256:c7a4e6926237d9e229244f201b330ac53a34c197456b75d3ec54a6f2e5aa384d
+        ../package.dhall sha256:302884c4ef81b8d5791314819bb4a96a7db71f215fd727747f93443b52ae6ef3
       ? ../package.dhall
 
 let config =

--- a/kubernetes/argocd/example/app.dhall
+++ b/kubernetes/argocd/example/app.dhall
@@ -1,6 +1,9 @@
 let argocd =
-        ../package.dhall sha256:302884c4ef81b8d5791314819bb4a96a7db71f215fd727747f93443b52ae6ef3
+        ../package.dhall sha256:ce61ca8208927e9595a030a3fa467eb48794979031c3d026b4dbd57e5cc9942d
       ? ../package.dhall
+      ? (   ../package.dhall sha256:ce61ca8208927e9595a030a3fa467eb48794979031c3d026b4dbd57e5cc9942d
+          ? ../package.dhall
+        )
 
 let config =
       argocd.util.AppConfig.DhallAppConfig

--- a/kubernetes/argocd/example/project.dhall
+++ b/kubernetes/argocd/example/project.dhall
@@ -1,6 +1,9 @@
 let argocd =
-        ../package.dhall sha256:302884c4ef81b8d5791314819bb4a96a7db71f215fd727747f93443b52ae6ef3
+        ../package.dhall sha256:ce61ca8208927e9595a030a3fa467eb48794979031c3d026b4dbd57e5cc9942d
       ? ../package.dhall
+      ? (   ../package.dhall sha256:ce61ca8208927e9595a030a3fa467eb48794979031c3d026b4dbd57e5cc9942d
+          ? ../package.dhall
+        )
 
 let k8s =
         ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a

--- a/kubernetes/argocd/example/project.dhall
+++ b/kubernetes/argocd/example/project.dhall
@@ -1,17 +1,18 @@
 let argocd =
-        ../package.dhall sha256:c7a4e6926237d9e229244f201b330ac53a34c197456b75d3ec54a6f2e5aa384d
+        ../package.dhall sha256:302884c4ef81b8d5791314819bb4a96a7db71f215fd727747f93443b52ae6ef3
       ? ../package.dhall
 
 let k8s =
-        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+        ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
       ? ../../k8s/1.15.dhall
 
 in  argocd.TypesUnion.Project
       argocd.Project::{
       , metadata = k8s.ObjectMeta::{
-        , name =
-              ./projectName.dhall sha256:d7e4e24f5750f02229d03a034faabf0f3378960c20170d83e78ab83c1131aded
-            ? ./projectName.dhall
+        , name = Some
+            (   ./projectName.dhall sha256:d7e4e24f5750f02229d03a034faabf0f3378960c20170d83e78ab83c1131aded
+              ? ./projectName.dhall
+            )
         }
       , spec = argocd.ProjectSpec::{
         , description = "ArgoCD Example Project"

--- a/kubernetes/argocd/package.dhall
+++ b/kubernetes/argocd/package.dhall
@@ -1,5 +1,5 @@
 { Application =
-      ./Application/package.dhall sha256:a6a0db9570250e7d94e9fcf7e79613fd9e12a5211c70030d58ff24fde2a4f765
+      ./Application/package.dhall sha256:c88bb716d8533593cda61e3ec65ce361a32bcd0f5d0849689ef1286cc43e1a51
     ? ./Application/package.dhall
 , ApplicationSpec =
       ./ApplicationSpec/package.dhall sha256:1fad326e2263f4ee6aa646f576be7b900c8e9ff5b275f1076da2c0a0ea39095f
@@ -41,7 +41,7 @@
       ./PluginSpec/package.dhall sha256:fd9dd420c9ea830231af7e7893ea217f2f7ca35c313cd0a319f80443ac6c84b9
     ? ./PluginSpec/package.dhall
 , Project =
-      ./Project/package.dhall sha256:94eb236942332300b6b8afcc4767272b156f440479d4bb1af5ac21a0b701f2d2
+      ./Project/package.dhall sha256:6a66066ed58b5e55c77ce9824e44dfe9dc26e2dfcfc217d4e80d3cf0afbd28cc
     ? ./Project/package.dhall
 , ProjectSpec =
       ./ProjectSpec/package.dhall sha256:4c9f9e00802ec63068f267006f3ecb66efbc9c6a927553eafc5862ce30da1f83
@@ -56,9 +56,9 @@
       ./SyncPolicyAutomated/package.dhall sha256:12684bfa3f833c4dd1c502ee5762762642a77e6cffe782ceec071325136215dd
     ? ./SyncPolicyAutomated/package.dhall
 , TypesUnion =
-      ./TypesUnion.dhall sha256:c1f91d90d8220d11f9ff8d745878da05ca9dc0af20a0792fe70c60c876308fc9
+      ./TypesUnion.dhall sha256:d44accc04431078bc49cb9adf3a7144a4a2e961082e26073146ee9181bdbaca5
     ? ./TypesUnion.dhall
 , util =
-      ./util/package.dhall sha256:4f830ea038c1c8ce07323e8e8ff56d470859f23ab4e7ae6f23e1d6b4b1247fb4
+      ./util/package.dhall sha256:034d6f7a84f12220f5e164c4e19d4ad5c0b1fecd1a5d95dd55c71b5e20b38cf6
     ? ./util/package.dhall
 }

--- a/kubernetes/argocd/util/internal/makeDhallApp.dhall
+++ b/kubernetes/argocd/util/internal/makeDhallApp.dhall
@@ -5,11 +5,11 @@
     for more information
 -}
 let TypesUnion =
-        ../../TypesUnion.dhall sha256:c1f91d90d8220d11f9ff8d745878da05ca9dc0af20a0792fe70c60c876308fc9
+        ../../TypesUnion.dhall sha256:d44accc04431078bc49cb9adf3a7144a4a2e961082e26073146ee9181bdbaca5
       ? ../../TypesUnion.dhall
 
 let Application =
-        ../../Application/package.dhall sha256:a6a0db9570250e7d94e9fcf7e79613fd9e12a5211c70030d58ff24fde2a4f765
+        ../../Application/package.dhall sha256:c88bb716d8533593cda61e3ec65ce361a32bcd0f5d0849689ef1286cc43e1a51
       ? ../../Application/package.dhall
 
 let ApplicationSpec =
@@ -29,7 +29,7 @@ let PluginSpec =
       ? ../../PluginSpec/package.dhall
 
 let k8s =
-        ../../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+        ../../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
       ? ../../../k8s/1.15.dhall
 
 in      \ ( appConfig
@@ -38,7 +38,7 @@ in      \ ( appConfig
           )
     ->    TypesUnion.Application
             Application::{
-            , metadata = k8s.ObjectMeta::{ name = appConfig.name }
+            , metadata = k8s.ObjectMeta::{ name = Some appConfig.name }
             , spec = ApplicationSpec::{
               , project = appConfig.project
               , source =

--- a/kubernetes/argocd/util/internal/makeHelmApp.dhall
+++ b/kubernetes/argocd/util/internal/makeHelmApp.dhall
@@ -1,9 +1,9 @@
 let TypesUnion =
-        ../../TypesUnion.dhall sha256:c1f91d90d8220d11f9ff8d745878da05ca9dc0af20a0792fe70c60c876308fc9
+        ../../TypesUnion.dhall sha256:d44accc04431078bc49cb9adf3a7144a4a2e961082e26073146ee9181bdbaca5
       ? ../../TypesUnion.dhall
 
 let Application =
-        ../../Application/package.dhall sha256:a6a0db9570250e7d94e9fcf7e79613fd9e12a5211c70030d58ff24fde2a4f765
+        ../../Application/package.dhall sha256:c88bb716d8533593cda61e3ec65ce361a32bcd0f5d0849689ef1286cc43e1a51
       ? ../../Application/package.dhall
 
 let ApplicationSpec =
@@ -23,7 +23,7 @@ let HelmSpec =
       ? ../../HelmSpec/package.dhall
 
 let k8s =
-        ../../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+        ../../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
       ? ../../../k8s/1.15.dhall
 
 in      \ ( appConfig
@@ -32,7 +32,7 @@ in      \ ( appConfig
           )
     ->    TypesUnion.Application
             Application::{
-            , metadata = k8s.ObjectMeta::{ name = appConfig.name }
+            , metadata = k8s.ObjectMeta::{ name = Some appConfig.name }
             , spec = ApplicationSpec::{
               , project = appConfig.project
               , source =

--- a/kubernetes/argocd/util/internal/makeKustomizeApp.dhall
+++ b/kubernetes/argocd/util/internal/makeKustomizeApp.dhall
@@ -1,9 +1,9 @@
 let TypesUnion =
-        ../../TypesUnion.dhall sha256:c1f91d90d8220d11f9ff8d745878da05ca9dc0af20a0792fe70c60c876308fc9
+        ../../TypesUnion.dhall sha256:d44accc04431078bc49cb9adf3a7144a4a2e961082e26073146ee9181bdbaca5
       ? ../../TypesUnion.dhall
 
 let Application =
-        ../../Application/package.dhall sha256:a6a0db9570250e7d94e9fcf7e79613fd9e12a5211c70030d58ff24fde2a4f765
+        ../../Application/package.dhall sha256:c88bb716d8533593cda61e3ec65ce361a32bcd0f5d0849689ef1286cc43e1a51
       ? ../../Application/package.dhall
 
 let ApplicationSpec =
@@ -23,7 +23,7 @@ let KustomizeSpec =
       ? ../../KustomizeSpec/package.dhall
 
 let k8s =
-        ../../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+        ../../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
       ? ../../../k8s/1.15.dhall
 
 in      \ ( appConfig
@@ -32,7 +32,7 @@ in      \ ( appConfig
           )
     ->    TypesUnion.Application
             Application::{
-            , metadata = k8s.ObjectMeta::{ name = appConfig.name }
+            , metadata = k8s.ObjectMeta::{ name = Some appConfig.name }
             , spec = ApplicationSpec::{
               , project = appConfig.project
               , source =

--- a/kubernetes/argocd/util/makeApp.dhall
+++ b/kubernetes/argocd/util/makeApp.dhall
@@ -4,13 +4,13 @@
       )
 ->  merge
       { DhallAppConfig =
-            ./internal/makeDhallApp.dhall sha256:629a0bee0eeb262d9961cda6b5a2723032e936c9b2e9c65a5f53694484f76ff5
+            ./internal/makeDhallApp.dhall sha256:d78b701fc5c2acd5b02a361619d782b42035aa82ec89990856b4fa5b9fb7b0c4
           ? ./internal/makeDhallApp.dhall
       , HelmAppConfig =
-            ./internal/makeHelmApp.dhall sha256:a224db08bfd698cbdf3b4715bcfca7bf94dfdfa8c253158dc390c5b177fa1cca
+            ./internal/makeHelmApp.dhall sha256:74bb363ba433417a8924df143ee692a90cb80c3bcc9a29128e243dc7d19b03fa
           ? ./internal/makeHelmApp.dhall
       , KustomizeAppConfig =
-            ./internal/makeKustomizeApp.dhall sha256:01861e0c982d50e79ce4dcad194dc85e235d3a04ec61cefb4337c94b5755fa13
+            ./internal/makeKustomizeApp.dhall sha256:aca267885643ff245a3f1595dd743505345337804e981c6065b00f0b3788f4ac
           ? ./internal/makeKustomizeApp.dhall
       }
       appConfig

--- a/kubernetes/argocd/util/package.dhall
+++ b/kubernetes/argocd/util/package.dhall
@@ -1,8 +1,8 @@
 { makeApp =
-      ./makeApp.dhall sha256:5b6c919309b9c5d098bd3569c4a3ebb396c9ac6c4e56e8b428d1b9af82dd2e80
+      ./makeApp.dhall sha256:7a7cbdf4fb4c7ed03ef5a88ba69c6da1f4700de51ea22f678d1aa5d12975956d
     ? ./makeApp.dhall
 , withSyncWave =
-      ./withSyncWave.dhall sha256:46e538c69e72ab64dc92d213cd3dfa7794576bed5fcbd77467e4f4d1ca176a65
+      ./withSyncWave.dhall sha256:237656f6f26c328ba9d2bc8687f522cee68084b5224d5afde08ce33016fefd07
     ? ./withSyncWave.dhall
 , AppConfig =
       ./AppConfig.dhall sha256:c610cee69a0557cfb4e4ec51de18a89201a4d7fc4ca2c9a6d4f2372f5c64d968

--- a/kubernetes/argocd/util/withSyncWave.dhall
+++ b/kubernetes/argocd/util/withSyncWave.dhall
@@ -2,28 +2,37 @@
     Utility to add sync waves to argocd applications and projects.
 -}
 let k8s =
-        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+        ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
       ? ../../k8s/1.15.dhall
 
 let Project =
-        ../Project/package.dhall sha256:94eb236942332300b6b8afcc4767272b156f440479d4bb1af5ac21a0b701f2d2
+        ../Project/package.dhall sha256:6a66066ed58b5e55c77ce9824e44dfe9dc26e2dfcfc217d4e80d3cf0afbd28cc
       ? ../Project/package.dhall
 
 let Application =
-        ../Application/package.dhall sha256:a6a0db9570250e7d94e9fcf7e79613fd9e12a5211c70030d58ff24fde2a4f765
+        ../Application/package.dhall sha256:c88bb716d8533593cda61e3ec65ce361a32bcd0f5d0849689ef1286cc43e1a51
       ? ../Application/package.dhall
 
 let TypesUnion =
-        ../TypesUnion.dhall sha256:c1f91d90d8220d11f9ff8d745878da05ca9dc0af20a0792fe70c60c876308fc9
+        ../TypesUnion.dhall sha256:d44accc04431078bc49cb9adf3a7144a4a2e961082e26073146ee9181bdbaca5
       ? ../TypesUnion.dhall
+
+let Optional/default =
+        https://prelude.dhall-lang.org/Optional/default sha256:5bd665b0d6605c374b3c4a7e2e2bd3b9c1e39323d41441149ed5e30d86e889ad
+      ? https://prelude.dhall-lang.org/Optional/default
 
 let withSyncWaveMetadata =
           \(wave : Integer)
       ->  \(metadata : k8s.ObjectMeta.Type)
       ->      metadata
-          //  { annotations =
-                    metadata.annotations
-                  # toMap { `argocd.argoproj.io/sync-wave` = Integer/show wave }
+          //  { annotations = Some
+                  (   Optional/default
+                        (List { mapKey : Text, mapValue : Text })
+                        ([] : List { mapKey : Text, mapValue : Text })
+                        metadata.annotations
+                    # toMap
+                        { `argocd.argoproj.io/sync-wave` = Integer/show wave }
+                  )
               }
 
 let withSyncWaveApplication =

--- a/kubernetes/cert-manager/Certificate/Type.dhall
+++ b/kubernetes/cert-manager/Certificate/Type.dhall
@@ -1,5 +1,5 @@
 let k8s =
-        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+        ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
       ? ../../k8s/1.15.dhall
 
 in  { apiVersion : Text

--- a/kubernetes/cert-manager/Certificate/package.dhall
+++ b/kubernetes/cert-manager/Certificate/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:1dbb054b3c4ae28f734dd89ca2c5cc74ab41c4bd714b1bda90d8d976b39bb09f
+      ./Type.dhall sha256:7ab781c605768b56c4ba492f694511471167a63726de994b7cff9afa9f641f1f
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:2a7868780bdf3b207d4fde4fe68df21dd23446ee313e47c5e6f04922a4b0daee

--- a/kubernetes/cert-manager/ClusterIssuer/Type.dhall
+++ b/kubernetes/cert-manager/ClusterIssuer/Type.dhall
@@ -1,5 +1,5 @@
 let k8s =
-        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+        ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
       ? ../../k8s/1.15.dhall
 
 in  { apiVersion : Text

--- a/kubernetes/cert-manager/ClusterIssuer/package.dhall
+++ b/kubernetes/cert-manager/ClusterIssuer/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:7c8a75ec834d854210836d559416b0db977444245a5c2e368a16bedb0c97c7f2
+      ./Type.dhall sha256:b3e68575113428c2f588215b5490ce7abef5e29c575387349a92ae7ed4bff1a0
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:2df5bda09440cc131439aeec0eb53b61b38946d8e20facea2adedb56ae80db81

--- a/kubernetes/cert-manager/Issuer/Type.dhall
+++ b/kubernetes/cert-manager/Issuer/Type.dhall
@@ -1,5 +1,5 @@
 let k8s =
-        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+        ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
       ? ../../k8s/1.15.dhall
 
 in  { apiVersion : Text

--- a/kubernetes/cert-manager/Issuer/package.dhall
+++ b/kubernetes/cert-manager/Issuer/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:7c8a75ec834d854210836d559416b0db977444245a5c2e368a16bedb0c97c7f2
+      ./Type.dhall sha256:b3e68575113428c2f588215b5490ce7abef5e29c575387349a92ae7ed4bff1a0
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:066a3a656894ad4817e764584a465e6749d14ca2b608673280cb87bafb4e7dde

--- a/kubernetes/cert-manager/TypesUnion.dhall
+++ b/kubernetes/cert-manager/TypesUnion.dhall
@@ -1,10 +1,10 @@
 < Certificate :
-      ./Certificate/Type.dhall sha256:1dbb054b3c4ae28f734dd89ca2c5cc74ab41c4bd714b1bda90d8d976b39bb09f
+      ./Certificate/Type.dhall sha256:7ab781c605768b56c4ba492f694511471167a63726de994b7cff9afa9f641f1f
     ? ./Certificate/Type.dhall
 | ClusterIssuer :
-      ./ClusterIssuer/Type.dhall sha256:7c8a75ec834d854210836d559416b0db977444245a5c2e368a16bedb0c97c7f2
+      ./ClusterIssuer/Type.dhall sha256:b3e68575113428c2f588215b5490ce7abef5e29c575387349a92ae7ed4bff1a0
     ? ./ClusterIssuer/Type.dhall
 | Issuer :
-      ./Issuer/Type.dhall sha256:7c8a75ec834d854210836d559416b0db977444245a5c2e368a16bedb0c97c7f2
+      ./Issuer/Type.dhall sha256:b3e68575113428c2f588215b5490ce7abef5e29c575387349a92ae7ed4bff1a0
     ? ./Issuer/Type.dhall
 >

--- a/kubernetes/cert-manager/package.dhall
+++ b/kubernetes/cert-manager/package.dhall
@@ -1,14 +1,14 @@
 { Certificate =
-      ./Certificate/package.dhall sha256:22d521ddc9adeb0db94f2b949b3e59c63b3284eff563c165447430c653efa013
+      ./Certificate/package.dhall sha256:344b67a24cda9968f1a673c4f6ab0669d97cbccf52e455e150365a47911e46ae
     ? ./Certificate/package.dhall
 , CertificateSpec =
       ./CertificateSpec/package.dhall sha256:c52995abc81eade41829faf4bb55c642a4ff82ab8d9e4abbd6b91a7e546a57f0
     ? ./CertificateSpec/package.dhall
 , ClusterIssuer =
-      ./ClusterIssuer/package.dhall sha256:e5b443639bc30733c050a2c758cb2161ea122b37077c0b51ede746607c6ce994
+      ./ClusterIssuer/package.dhall sha256:47614640ea7bcc4a2c59f27ade3c92dac21f559dc54e8e581549682daa5c225f
     ? ./ClusterIssuer/package.dhall
 , Issuer =
-      ./Issuer/package.dhall sha256:d84ac9132428aff26123c8866c155c0990d5f52d83128b58b910700bb0209baa
+      ./Issuer/package.dhall sha256:a02686f32595cfd7ba239ff6cc982e24d376598316b290f0e97c4ff936b1c1fa
     ? ./Issuer/package.dhall
 , IssuerSpec =
       ./IssuerSpec/Type.dhall sha256:f6653c04550257450fe39a85745801ae60fe643acf09308f0f8b336517f9a4e3
@@ -20,6 +20,6 @@
       ./CAIssuerSpec/package.dhall sha256:7648f583fe9765effdb9f80ce73ad8d2d97b4014b7f1bb4caaa91c06e812c79a
     ? ./CAIssuerSpec/package.dhall
 , TypesUnion =
-      ./TypesUnion.dhall sha256:8d01d4506f3fa1db74e435af6f394dc65fc4b8e50fc46533cb00791a8dfc9ed6
+      ./TypesUnion.dhall sha256:2e652531043f38d9b95b88f3acc118d83092e619fa11610a22f1c01b34325b97
     ? ./TypesUnion.dhall
 }

--- a/kubernetes/k8s/1.14.dhall
+++ b/kubernetes/k8s/1.14.dhall
@@ -1,2 +1,2 @@
-  https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.14/package.dhall sha256:7839bf40f940757e4d71d3c1b84d878f6a4873c3b2706ae4be307b5991acdcac
-? https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.14/package.dhall
+  https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/2ed2ffd073de6569014779284b61e4f5824de987/1.14/package.dhall sha256:efab6966e82aa9d30e9089fa8e84bb9524cbe5e193c45c5ff6eb07837d05fecb
+? https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/2ed2ffd073de6569014779284b61e4f5824de987/1.14/package.dhall

--- a/kubernetes/k8s/1.15.dhall
+++ b/kubernetes/k8s/1.15.dhall
@@ -1,2 +1,2 @@
-  https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.15/package.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
-? https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.15/package.dhall
+  https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/2ed2ffd073de6569014779284b61e4f5824de987/1.15/package.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
+? https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/2ed2ffd073de6569014779284b61e4f5824de987/1.15/package.dhall

--- a/kubernetes/k8s/1.16.dhall
+++ b/kubernetes/k8s/1.16.dhall
@@ -1,2 +1,2 @@
-  https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.16/package.dhall sha256:ab1c971ddeb178c1cfc5e749b211b4fe6fdb6fa1b68b10de62aeb543efcd60b3
-? https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.16/package.dhall
+  https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/2ed2ffd073de6569014779284b61e4f5824de987/1.16/package.dhall sha256:fd1af291ba9c386400002168b8340cf1bf9589511d5437a33e59a017e90b1b35
+? https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/2ed2ffd073de6569014779284b61e4f5824de987/1.16/package.dhall

--- a/kubernetes/k8s/1.17.dhall
+++ b/kubernetes/k8s/1.17.dhall
@@ -1,2 +1,2 @@
-  https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.17/package.dhall sha256:e9c55c7ff71f901314129e7ef100c3af5ec7a918dce25e06d83fa8c5472cb680
-? https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/6a47bd50c4d3984a13570ea62382a3ad4a9919a4/1.17/package.dhall
+  https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/2ed2ffd073de6569014779284b61e4f5824de987/1.17/package.dhall sha256:532e110f424ea8a9f960a13b2ca54779ddcac5d5aa531f86d82f41f8f18d7ef1
+? https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/2ed2ffd073de6569014779284b61e4f5824de987/1.17/package.dhall

--- a/kubernetes/k8s/package.dhall
+++ b/kubernetes/k8s/package.dhall
@@ -1,13 +1,13 @@
 { `1-14` =
-      ./1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ./1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
     ? ./1.15.dhall
 , `1-15` =
-      ./1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+      ./1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
     ? ./1.15.dhall
 , `1-16` =
-      ./1.16.dhall sha256:ab1c971ddeb178c1cfc5e749b211b4fe6fdb6fa1b68b10de62aeb543efcd60b3
+      ./1.16.dhall sha256:fd1af291ba9c386400002168b8340cf1bf9589511d5437a33e59a017e90b1b35
     ? ./1.16.dhall
 , `1-17` =
-      ./1.17.dhall sha256:e9c55c7ff71f901314129e7ef100c3af5ec7a918dce25e06d83fa8c5472cb680
+      ./1.17.dhall sha256:532e110f424ea8a9f960a13b2ca54779ddcac5d5aa531f86d82f41f8f18d7ef1
     ? ./1.17.dhall
 }

--- a/kubernetes/kubernetes-external-secrets/ExternalSecret/Type.dhall
+++ b/kubernetes/kubernetes-external-secrets/ExternalSecret/Type.dhall
@@ -1,5 +1,5 @@
 let k8s =
-        ../../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+        ../../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
       ? ../../k8s/1.15.dhall
 
 in  { apiVersion : Text

--- a/kubernetes/kubernetes-external-secrets/ExternalSecret/package.dhall
+++ b/kubernetes/kubernetes-external-secrets/ExternalSecret/package.dhall
@@ -1,5 +1,5 @@
 { Type =
-      ./Type.dhall sha256:5555b647cc276a5fb9fa36b086b5e3ef0dea6b8dd7045654b40a48e320fcb61a
+      ./Type.dhall sha256:14c7f406c077f25335afc6ca6a47aac3eaf084e603c7183171077014a505b97f
     ? ./Type.dhall
 , default =
       ./default.dhall sha256:fb479794b0f34d01df52b6c69e684cef045061bf25eb496345dc85968563c231

--- a/kubernetes/kubernetes-external-secrets/package.dhall
+++ b/kubernetes/kubernetes-external-secrets/package.dhall
@@ -2,7 +2,7 @@
       ./BackendType/package.dhall sha256:8a611d85765bbc1962b973518fb2cc14adf28df15be2d12c9b63769d0a8cdc9a
     ? ./BackendType/package.dhall
 , ExternalSecret =
-      ./ExternalSecret/package.dhall sha256:6132f56377abd6ab74bd8eefabfb110ec78a487f10d9b8ef56e1430ef88e28c3
+      ./ExternalSecret/package.dhall sha256:34693944ebfb97a255271f3239496cebed3af8f3321f69f70d9702e23f5b2d8b
     ? ./ExternalSecret/package.dhall
 , SecretsManagerExternalData =
       ./SecretsManagerExternalData/package.dhall sha256:06e4b16d312bf0cade699e35b6204e4f72da8988751665ba9887d75c0712c457

--- a/kubernetes/package.dhall
+++ b/kubernetes/package.dhall
@@ -1,25 +1,25 @@
 { cert-manager =
-      ./cert-manager/package.dhall sha256:1249e3f2a27a1b46b5bd726c81f9424735a8e85344aba173705147b21560a384
+      ./cert-manager/package.dhall sha256:1640fd5080778e8e9f565cf5790efe18ba9aa57599248b3c75425825be4ef739
     ? ./cert-manager/package.dhall
 , kubernetes-external-secrets =
-      ./kubernetes-external-secrets/package.dhall sha256:7150f631a6ae9368732b0d6c0db279da1b4b84f3cdfb90270db7c785a4291c07
+      ./kubernetes-external-secrets/package.dhall sha256:8647ab484b4fb30bd527db24c7aa018c39ba4603ab9d1e03cd6ecc9d15b35ed2
     ? ./kubernetes-external-secrets/package.dhall
 , k8s =
-      ./k8s/package.dhall sha256:99637fe8405be855dd75004ac00251f54432cc151c7e64bf13a9e6602513281b
+      ./k8s/package.dhall sha256:b217e73b9d72f3346faf61f9c41b2b26a1d8d00a8ca0c8439eacec35cee0bf8d
     ? ./k8s/package.dhall
 , argocd =
-      ./argocd/package.dhall sha256:c7a4e6926237d9e229244f201b330ac53a34c197456b75d3ec54a6f2e5aa384d
+      ./argocd/package.dhall sha256:ce61ca8208927e9595a030a3fa467eb48794979031c3d026b4dbd57e5cc9942d
     ? ./argocd/package.dhall
 , argo =
-      ./argo/package.dhall sha256:d609a81190e145aa02bdd0e32aa8f018360946883f7a7706066a0fd4c6decc53
+      ./argo/package.dhall sha256:7435a45fd240d3073f925c4ed5ad938d318757458ecdad5a32568feb27853021
     ? ./argo/package.dhall
 , argo-events =
       ./argo-events/package.dhall sha256:c1dfad4c982bb700c2d2dcb7adbc325f5e67d1eb016a04551d41085411958c52
     ? ./argo-events/package.dhall
 , ambassador =
-      ./ambassador/package.dhall sha256:24f35c2f19dace8e899148f03da017a086334583f7ab4b9a0d73afca9bd6a091
+      ./ambassador/package.dhall sha256:ca7db0c29acb78594833475fe737a918a943557139f1dce5e73f1e195453acde
     ? ./ambassador/package.dhall
 , webhook =
-      ./webhook/package.dhall sha256:ddb9f54f2f15cc2ec9e4106db0d98a68f28fbc2c58d92d36f1a5e2280aaa0bea
+      ./webhook/package.dhall sha256:1089dfd1e3a5abd70b5c95ce33e870b14a6a9c552ff8985e4b97080727aeb094
     ? ./webhook/package.dhall
 }

--- a/kubernetes/webhook/Type.dhall
+++ b/kubernetes/webhook/Type.dhall
@@ -1,5 +1,5 @@
 let k8s =
-        ../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+        ../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
       ? ../k8s/1.15.dhall
 
 in  { name : Text

--- a/kubernetes/webhook/default.dhall
+++ b/kubernetes/webhook/default.dhall
@@ -1,5 +1,5 @@
 let k8s =
-        ../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+        ../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
       ? ../k8s/1.15.dhall
 
 in  { namespaceSelector = None k8s.LabelSelector.Type

--- a/kubernetes/webhook/example.dhall
+++ b/kubernetes/webhook/example.dhall
@@ -1,9 +1,9 @@
 let Webhook =
-        ./package.dhall sha256:ddb9f54f2f15cc2ec9e4106db0d98a68f28fbc2c58d92d36f1a5e2280aaa0bea
+        ./package.dhall sha256:1089dfd1e3a5abd70b5c95ce33e870b14a6a9c552ff8985e4b97080727aeb094
       ? ./package.dhall
 
 let k8s =
-        ../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+        ../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
       ? ../k8s/1.15.dhall
 
 let exampleWebhook =

--- a/kubernetes/webhook/labels.dhall
+++ b/kubernetes/webhook/labels.dhall
@@ -1,5 +1,5 @@
 let Webhook =
-        ./Type.dhall sha256:c833a7c500b51ebe0c1879967d11b476428a885b276d70e5f8cc3b4da09890ad
+        ./Type.dhall sha256:a71ac5b5469ecd2b6823ef59404fdf2878a24138028baa1697a3deadc8e9be73
       ? ./Type.dhall
 
 let labels = \(config : Webhook) -> toMap { app = config.name }

--- a/kubernetes/webhook/package.dhall
+++ b/kubernetes/webhook/package.dhall
@@ -2,9 +2,9 @@
       ? ./schema.dhall
     )
 /\  { renderMutatingWebhook =
-          ./renderMutatingWebhook.dhall sha256:594c7722600cf2d5b82f786e972ada53dc233ef2e7be20492df35f858d46e858
+          ./renderMutatingWebhook.dhall sha256:59fbebfe4442f0e8b0c660c1e576c23d645f5fb36cda6fb97529425a465b2f7b
         ? ./renderMutatingWebhook.dhall
     , renderValidatingWebhook =
-          ./renderValidatingWebhook.dhall sha256:5abd45ccbca34e7e2cb69826c5636c8cb9fb26baa31c12add82251651c133c5f
+          ./renderValidatingWebhook.dhall sha256:808f1a5ab92562cb11e7a3602f4125df840bc5ab9891722f6c797463bfe1a02a
         ? ./renderValidatingWebhook.dhall
     }

--- a/kubernetes/webhook/renderMutatingWebhook.dhall
+++ b/kubernetes/webhook/renderMutatingWebhook.dhall
@@ -1,40 +1,45 @@
 let k8s =
-        ../k8s/1.15.dhall sha256:4bd5939adb0a5fc83d76e0d69aa3c5a30bc1a5af8f9df515f44b6fc59a0a4815
+        ../k8s/1.15.dhall sha256:9ed8981915875f3bbe08ad7047d92cd181b6ece140af876beecadb8ed079e10a
       ? ../k8s/1.15.dhall
 
 let cert-manager =
-        ../cert-manager/package.dhall sha256:1249e3f2a27a1b46b5bd726c81f9424735a8e85344aba173705147b21560a384
+        ../cert-manager/package.dhall sha256:1640fd5080778e8e9f565cf5790efe18ba9aa57599248b3c75425825be4ef739
       ? ../cert-manager/package.dhall
 
 let certsPath = "/certs"
 
 let Webhook =
-        ./Type.dhall sha256:c833a7c500b51ebe0c1879967d11b476428a885b276d70e5f8cc3b4da09890ad
+        ./Type.dhall sha256:a71ac5b5469ecd2b6823ef59404fdf2878a24138028baa1697a3deadc8e9be73
       ? ./Type.dhall
 
 let labels =
-        ./labels.dhall sha256:05c731fe37f21baf0f03bdbe393472a33ba7dd791b924c5ecc2696042f27d6fc
+        ./labels.dhall sha256:1cf6971c63fef213125cc10c5ecf5c32df954da0e186943693994121485f67e1
       ? ./labels.dhall
 
 let deployment =
           \(webhook : Webhook)
       ->  k8s.Deployment::{
-          , metadata = k8s.ObjectMeta::{ name = webhook.name }
+          , metadata = k8s.ObjectMeta::{ name = Some webhook.name }
           , spec = Some k8s.DeploymentSpec::{
-            , selector = k8s.LabelSelector::{ matchLabels = labels webhook }
+            , selector = k8s.LabelSelector::{
+              , matchLabels = Some (labels webhook)
+              }
             , template = k8s.PodTemplateSpec::{
-              , metadata = k8s.ObjectMeta::{
-                , name = webhook.name
-                , labels = labels webhook
+              , metadata = Some k8s.ObjectMeta::{
+                , name = Some webhook.name
+                , labels = Some (labels webhook)
                 }
               , spec = Some k8s.PodSpec::{
                 , containers =
                   [ k8s.Container::{
                     , name = webhook.name
                     , image = Some webhook.imageName
-                    , ports =
-                      [ k8s.ContainerPort::{ containerPort = webhook.port } ]
-                    , env =
+                    , ports = Some
+                      [ k8s.ContainerPort::{
+                        , containerPort = Natural/toInteger webhook.port
+                        }
+                      ]
+                    , env = Some
                       [ k8s.EnvVar::{
                         , name = "CERTIFICATE_FILE"
                         , value = Some "${certsPath}/tls.crt"
@@ -48,7 +53,7 @@ let deployment =
                         , value = Some (Natural/show webhook.port)
                         }
                       ]
-                    , volumeMounts =
+                    , volumeMounts = Some
                       [ k8s.VolumeMount::{
                         , name = "certs"
                         , mountPath = certsPath
@@ -57,7 +62,7 @@ let deployment =
                       ]
                     }
                   ]
-                , volumes =
+                , volumes = Some
                   [ k8s.Volume::{
                     , name = "certs"
                     , secret = Some k8s.SecretVolumeSource::{
@@ -73,13 +78,14 @@ let deployment =
 let service =
           \(webhook : Webhook)
       ->  k8s.Service::{
-          , metadata = k8s.ObjectMeta::{ name = webhook.name }
+          , metadata = k8s.ObjectMeta::{ name = Some webhook.name }
           , spec = Some k8s.ServiceSpec::{
-            , selector = labels webhook
-            , ports =
+            , selector = Some (labels webhook)
+            , ports = Some
               [ k8s.ServicePort::{
-                , targetPort = Some (k8s.IntOrString.Int webhook.port)
-                , port = 443
+                , targetPort = Some
+                    (k8s.IntOrString.Int (Natural/toInteger webhook.port))
+                , port = Natural/toInteger 443
                 }
               ]
             }
@@ -88,7 +94,7 @@ let service =
 let issuer =
           \(webhook : Webhook)
       ->  cert-manager.Issuer::{
-          , metadata = k8s.ObjectMeta::{ name = webhook.name }
+          , metadata = k8s.ObjectMeta::{ name = Some webhook.name }
           , spec =
               cert-manager.IssuerSpec.SelfSigned
                 cert-manager.SelfSignedIssuerSpec::{=}
@@ -97,7 +103,7 @@ let issuer =
 let certificate =
           \(webhook : Webhook)
       ->  cert-manager.Certificate::{
-          , metadata = k8s.ObjectMeta::{ name = webhook.name }
+          , metadata = k8s.ObjectMeta::{ name = Some webhook.name }
           , spec = cert-manager.CertificateSpec::{
             , secretName = webhook.name
             , issuerRef = { name = webhook.name, kind = (issuer webhook).kind }
@@ -122,14 +128,16 @@ let mutatingWebhookConfiguration =
           \(webhook : Webhook)
       ->  k8s.MutatingWebhookConfiguration::{
           , metadata = k8s.ObjectMeta::{
-            , name = webhook.name
-            , labels = labels webhook
-            , annotations = toMap
-                { `cert-manager.io/inject-ca-from` =
-                    "${webhook.namespace}/${webhook.name}"
-                }
+            , name = Some webhook.name
+            , labels = Some (labels webhook)
+            , annotations = Some
+                ( toMap
+                    { `cert-manager.io/inject-ca-from` =
+                        "${webhook.namespace}/${webhook.name}"
+                    }
+                )
             }
-          , webhooks =
+          , webhooks = Some
             [ k8s.MutatingWebhook::{
               , name = "${webhook.name}.${webhook.namespace}.svc"
               , clientConfig = k8s.WebhookClientConfig::{
@@ -137,12 +145,12 @@ let mutatingWebhookConfiguration =
                   { name = webhook.name
                   , namespace = webhook.namespace
                   , path = Some webhook.path
-                  , port = Some 443
+                  , port = Some (Natural/toInteger 443)
                   }
                 }
               , failurePolicy = webhook.failurePolicy
-              , admissionReviewVersions = [ "v1beta1" ]
-              , rules = webhook.rules
+              , admissionReviewVersions = Some [ "v1beta1" ]
+              , rules = Some webhook.rules
               , namespaceSelector = webhook.namespaceSelector
               }
             ]

--- a/package.dhall
+++ b/package.dhall
@@ -1,5 +1,5 @@
 { kubernetes =
-      ./kubernetes/package.dhall sha256:0e31269f0490a88e53a4d783cdefc657998a548e53594efaa453daf560afa5d5
+      ./kubernetes/package.dhall sha256:22146f59a6fca418d5dca44d9ff15bdf138cec68e81926c87e97fb0dc231230e
     ? ./kubernetes/package.dhall
 , Prelude =
       https://prelude.dhall-lang.org/v15.0.0/package.dhall sha256:6b90326dc39ab738d7ed87b970ba675c496bed0194071b332840a87261649dcd


### PR DESCRIPTION
intended to upgrade dhall and k8s-common-applications however due to the
number of breaking changes here that seems unlikely.  I'd like to see
this through and see if I can limit the upgrade to the webservice template
where I'd like to take advantage of some improvements to the schema
around optional